### PR TITLE
feat: hook that watches system theme

### DIFF
--- a/packages/hooks/src/useSystemTheme.ts
+++ b/packages/hooks/src/useSystemTheme.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+export enum THEME {
+  light = 'light',
+  dark = 'dark',
+}
+
+export const useSystemTheme = (): THEME => {
+  const [systemTheme, setSystemTheme] = useState(THEME.light)
+
+  useEffect(() => {
+    try {
+      const mql = window.matchMedia('(prefers-color-scheme: dark)')
+
+      const setThemeFromQuery = ({ matches }: { matches: boolean }) => {
+        setSystemTheme(matches ? THEME.dark : THEME.light)
+      }
+
+      mql.addEventListener('change', setThemeFromQuery)
+      setThemeFromQuery(mql)
+
+      return () => {
+        mql.removeEventListener('change', setThemeFromQuery)
+      }
+    } catch (error) {
+      return
+    }
+  }, [])
+
+  return systemTheme
+}

--- a/packages/hooks/src/useSystemTheme.ts
+++ b/packages/hooks/src/useSystemTheme.ts
@@ -9,21 +9,17 @@ export const useSystemTheme = (): THEME => {
   const [systemTheme, setSystemTheme] = useState(THEME.light)
 
   useEffect(() => {
-    try {
-      const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
 
-      const setThemeFromQuery = ({ matches }: { matches: boolean }) => {
-        setSystemTheme(matches ? THEME.dark : THEME.light)
-      }
+    const setThemeFromQuery = ({ matches }: { matches: boolean }) => {
+      setSystemTheme(matches ? THEME.dark : THEME.light)
+    }
 
-      mql.addEventListener('change', setThemeFromQuery)
-      setThemeFromQuery(mql)
+    mql.addEventListener('change', setThemeFromQuery)
+    setThemeFromQuery(mql)
 
-      return () => {
-        mql.removeEventListener('change', setThemeFromQuery)
-      }
-    } catch (error) {
-      return
+    return () => {
+      mql.removeEventListener('change', setThemeFromQuery)
     }
   }, [])
 


### PR DESCRIPTION
This PR includes a hook that watches OS color mode changes and outputs either `light` or `dark` according. Subscribe to the hook's output to change your apps color scheme accordingly.