### PR TITLE
Fix: Removing default for system theme identification hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Check out our Storybook at [https://ui.lido.fi](https://ui.lido.fi)
 
+## Breaking Changes
+
+`useSystemTheme` hook will no longer return light theme as a fallback when system theme was not identified. A check needs to be added after upgrading.
+
 ## Getting Started
 
 Simply add `lido-ui` to your dependencies:

--- a/packages/hooks/src/useSystemTheme.ts
+++ b/packages/hooks/src/useSystemTheme.ts
@@ -5,8 +5,8 @@ export enum THEME {
   dark = 'dark',
 }
 
-export const useSystemTheme = (): THEME => {
-  const [systemTheme, setSystemTheme] = useState(THEME.light)
+export const useSystemTheme = (): THEME | undefined => {
+  const [systemTheme, setSystemTheme] = useState<THEME>()
 
   useEffect(() => {
     const mql = window.matchMedia('(prefers-color-scheme: dark)')


### PR DESCRIPTION
Removes default value for system theme hook: if we don't know what system theme is, we should pass that so apps can handle it themselves.

Breaking change: affects app logic.