### PR TITLE
Modal: rework, add Back button, add Subtitle

### DIFF
--- a/packages/icons/src/index.tsx
+++ b/packages/icons/src/index.tsx
@@ -2,6 +2,31 @@
 
 import * as React from 'react'
 
+export const ArrowBack = React.forwardRef(function ArrowBack(
+  props: React.SVGProps<SVGSVGElement>,
+  svgRef?: React.Ref<SVGSVGElement>
+) {
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox='0 0 24 24'
+      fill='currentColor'
+      ref={svgRef}
+      {...props}
+    >
+      <path
+        d='M20 12H4m6 6l-6-6 6-6'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth={2}
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  )
+})
+
 export const ArrowBottom = React.forwardRef(function ArrowBottom(
   props: React.SVGProps<SVGSVGElement>,
   svgRef?: React.Ref<SVGSVGElement>

--- a/packages/icons/src/svg/arrow-back.svg
+++ b/packages/icons/src/svg/arrow-back.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 12H4m6 6l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/modal/src/Modal.stories.tsx
+++ b/packages/modal/src/Modal.stories.tsx
@@ -19,6 +19,7 @@ export default {
   title: 'Dialogs/Modal',
   args: {
     title: 'Modal Title',
+    subtitle: '',
     children: 'Modal content',
     center: false,
   },
@@ -31,15 +32,18 @@ export default {
 } as Meta
 
 const useModal = (props: ModalProps) => {
-  const { onClose } = props
+  const { onClose, onBack } = props
   const [state, setState] = useState(false)
   const handleOpen = useCallback(() => setState(true), [])
   const handleClose = useCallback(() => {
     setState(false)
     onClose?.()
   }, [onClose])
+  const handleBack = useCallback(() => {
+    onBack?.()
+  }, [onBack])
 
-  return { state, handleOpen, handleClose }
+  return { state, handleOpen, handleClose, handleBack }
 }
 
 export const Basic: Story<ModalProps> = (props) => {
@@ -64,6 +68,22 @@ export const ExtraContent: Story<ModalProps> = (props) => {
         open={state}
         onClose={handleClose}
         extra={<ModalExtra>Extra content</ModalExtra>}
+      />
+    </>
+  )
+}
+
+export const WithBackButton: Story<ModalProps> = (props) => {
+  const { state, handleOpen, handleClose, handleBack } = useModal(props)
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Show modal</Button>
+      <Modal
+        {...props}
+        open={state}
+        onClose={handleClose}
+        onBack={handleBack}
       />
     </>
   )
@@ -95,9 +115,6 @@ export const LoadingStateInModal: Story<ModalProps> = (props) => {
         open={state}
         onClose={handleClose}
       >
-        <Text color='secondary' size='xxs'>
-          Staking 10 ETH. You will receive 10 stETH
-        </Text>
         <br />
         <Text color='secondary' size='xxs'>
           Confirm this transaction in your wallet
@@ -109,6 +126,7 @@ export const LoadingStateInModal: Story<ModalProps> = (props) => {
 
 LoadingStateInModal.args = {
   title: 'You are now staking 10 ETH',
+  subtitle: 'Staking 10 ETH. You will receive 10 stETH',
   center: true,
 }
 
@@ -133,9 +151,6 @@ export const SuccessStateInModal: Story<ModalProps> = (props) => {
         open={state}
         onClose={handleClose}
       >
-        <Text color='secondary' size='xxs'>
-          Staking operation was successful
-        </Text>
         <br />
         <Link href={'https://etherscan.io/'}>View on Etherscan</Link>
       </Modal>
@@ -145,6 +160,7 @@ export const SuccessStateInModal: Story<ModalProps> = (props) => {
 
 SuccessStateInModal.args = {
   title: 'Your new balance is 10 stETH',
+  subtitle: 'Staking operation was successful',
   center: true,
 }
 
@@ -169,9 +185,6 @@ export const ErrorStateInModal: Story<ModalProps> = (props) => {
         open={state}
         onClose={handleClose}
       >
-        <Text color='secondary' size='xxs'>
-          Staking operation was not successful
-        </Text>
         <br />
         <Link href={'#'}>Retry</Link>
       </Modal>
@@ -181,6 +194,7 @@ export const ErrorStateInModal: Story<ModalProps> = (props) => {
 
 ErrorStateInModal.args = {
   title: 'Something went wrong',
+  subtitle: 'Staking operation was not successful',
   center: true,
 }
 

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -6,8 +6,11 @@ import {
   ModalHeaderStyle,
   ModalTitleStyle,
   ModalTitleIconStyle,
+  ModalTitleTextStyle,
   ModalCloseStyle,
   ModalContentStyle,
+  ModalBackStyle,
+  ModalSubtitleStyle,
 } from './ModalStyles'
 import { ModalProps } from './types'
 import ModalOverlay from './ModalOverlay'
@@ -17,43 +20,45 @@ function Modal(props: ModalProps, ref?: ForwardedRef<HTMLDivElement>) {
     children,
     title,
     titleIcon,
+    subtitle,
     center = false,
     extra,
     open,
     ...rest
   } = props
-  const { onClose } = props
+  const { onClose, onBack } = props
 
-  const closable = !!onClose
-  const untitled = !title
+  const withTitleIcon = !!titleIcon
+  const withSubtitle = !!subtitle
+  const withCloseButton = !!onClose
+  const withBackButton = !!onBack
 
-  let modalHeader
-  if (titleIcon) {
-    modalHeader = (
-      <ModalHeaderStyle $short={untitled} $withTitleIcon={true}>
-        <ModalTitleStyle $center={center} $withTitleIcon={true}>
-          <ModalTitleIconStyle>{titleIcon}</ModalTitleIconStyle>
-          {title}
-        </ModalTitleStyle>
-        {closable && <ModalCloseStyle onClick={onClose} />}
-      </ModalHeaderStyle>
-    )
-  } else {
-    modalHeader = (
-      <ModalHeaderStyle $short={untitled} $withTitleIcon={false}>
-        <ModalTitleStyle $center={center} $withTitleIcon={false}>
-          {title}
-        </ModalTitleStyle>
-        {closable && <ModalCloseStyle onClick={onClose} />}
-      </ModalHeaderStyle>
-    )
-  }
+  const modalHeader = (
+    <ModalHeaderStyle $short={!title}>
+      {withBackButton && <ModalBackStyle onClick={onBack} />}
+      <ModalTitleStyle
+        $center={center}
+        $withTitleIcon={withTitleIcon}
+        $withCloseButton={withCloseButton}
+        $withBackButton={withBackButton}
+      >
+        {!!titleIcon && (
+          <ModalTitleIconStyle $center={center}>
+            {titleIcon}
+          </ModalTitleIconStyle>
+        )}
+        <ModalTitleTextStyle>{title}</ModalTitleTextStyle>
+      </ModalTitleStyle>
+      {withCloseButton && <ModalCloseStyle onClick={onClose} />}
+    </ModalHeaderStyle>
+  )
 
   return (
     <ModalOverlay in={open} {...rest} ref={ref}>
       <ModalStyle $center={center}>
         <ModalBaseStyle>
           {modalHeader}
+          {withSubtitle && <ModalSubtitleStyle>{subtitle}</ModalSubtitleStyle>}
           <ModalContentStyle>{children}</ModalContentStyle>
         </ModalBaseStyle>
         {extra}

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -42,7 +42,7 @@ function Modal(props: ModalProps, ref?: ForwardedRef<HTMLDivElement>) {
         $withCloseButton={withCloseButton}
         $withBackButton={withBackButton}
       >
-        {!!titleIcon && (
+        {withTitleIcon && (
           <ModalTitleIconStyle $center={center}>
             {titleIcon}
           </ModalTitleIconStyle>

--- a/packages/modal/src/ModalOverlay.tsx
+++ b/packages/modal/src/ModalOverlay.tsx
@@ -16,7 +16,7 @@ function ModalOverlay(
   props: ModalOverlayInnerProps,
   externalRef?: ForwardedRef<HTMLDivElement>
 ) {
-  const { onClose, duration, transitionStatus, ...rest } = props
+  const { onClose, onBack, duration, transitionStatus, ...rest } = props
   const closable = !!onClose
 
   useEscape(onClose)

--- a/packages/modal/src/ModalStyles.tsx
+++ b/packages/modal/src/ModalStyles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Close } from '@lidofinance/icons'
+import { Close, ArrowBack } from '@lidofinance/icons'
 import { ButtonIcon } from '@lidofinance/button'
 
 export const ModalStyle = styled.div<{ $center: boolean }>`
@@ -24,65 +24,78 @@ export const ModalBaseStyle = styled.div`
 
 export const ModalHeaderStyle = styled.div<{
   $short: boolean
-  $withTitleIcon: boolean
 }>`
   display: flex;
-  align-items: ${({ $withTitleIcon }) =>
-    $withTitleIcon ? 'flex-start' : 'center'};
+  align-items: flex-start;
   min-height: 32px;
-  margin: 0;
   margin-bottom: ${({ $short, theme }) => ($short ? -theme.spaceMap.md : 0)}px;
-  padding: ${({ theme }) => theme.spaceMap.xl}px
-    ${({ theme }) => theme.spaceMap.xxl}px;
+  padding: ${({ theme }) => theme.spaceMap.xl}px;
   font-size: ${({ theme }) => theme.fontSizesMap.md}px;
   line-height: 1.5em;
 
   ${({ theme }) => theme.mediaQueries.md} {
-    padding: ${({ theme }) => theme.spaceMap.xl}px
-      ${({ theme }) => theme.spaceMap.lg}px;
+    padding: ${({ theme }) => theme.spaceMap.lg}px;
   }
 `
 
 export const ModalTitleStyle = styled.div<{
   $center: boolean
   $withTitleIcon: boolean
+  $withCloseButton: boolean
+  $withBackButton: boolean
 }>`
-  font-size: ${({ theme }) => theme.fontSizesMap.md}px;
+  font-size: ${({ theme }) => theme.fontSizesMap.sm}px;
   line-height: 1.5em;
-  font-weight: 800;
-  margin-right: auto;
-  padding-right: 32px;
-  padding-left: ${({ $center }) => ($center ? '32px' : '0px')};
-  padding-top: ${({ $withTitleIcon }) => ($withTitleIcon ? '40px' : '0')};
-  margin-bottom: -20px;
+  font-weight: 700;
+  margin-left: ${({ theme, $center, $withBackButton }) =>
+    $center && !$withBackButton ? theme.spaceMap.xxl : '0'}px;
+  margin-right: ${({ theme, $center, $withCloseButton }) =>
+    $center && !$withCloseButton ? theme.spaceMap.xxl : '0'}px;
+  padding-top: ${({ theme, $withTitleIcon }) =>
+    $withTitleIcon ? theme.spaceMap.sm : '0'}px;
+  padding-left: ${({ theme }) => theme.spaceMap.sm}px;
+  padding-right: ${({ theme }) => theme.spaceMap.sm}px;
   flex-grow: 1;
+  align-self: center;
 
-  ${({ $center, $withTitleIcon }) =>
+  ${({ theme }) => theme.mediaQueries.md} {
+    padding-left: ${({ theme }) => theme.spaceMap.xs}px;
+    padding-right: ${({ theme }) => theme.spaceMap.xs}px;
+  }
+`
+
+export const ModalTitleIconStyle = styled.div<{
+  $center: boolean
+}>`
+  line-height: 0.7;
+  margin-bottom: ${({ theme }) => theme.spaceMap.md}px;
+
+  ${({ $center }) =>
     $center &&
-    $withTitleIcon &&
     `
     display: flex;
-    flex-direction: column;
-    align-items: center;
+    justify-content: center;
   `}
 `
 
-export const ModalTitleIconStyle = styled.div`
-  padding-bottom: ${({ theme }) => theme.spaceMap.xl}px;
+export const ModalTitleTextStyle = styled.div`
+  margin: ${({ theme }) => theme.spaceMap.xs}px 0;
 `
 
-export const ModalCloseStyle = styled(ButtonIcon).attrs({
-  icon: <Close />,
-  color: 'secondary',
-  variant: 'ghost',
-  size: 'xs',
-})`
-  flex-shrink: 0;
-  margin: 0 -10px 0 -22px;
-  border-radius: 50%;
+export const ModalSubtitleStyle = styled.div`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
+  font-weight: 400;
+  line-height: 24px;
+  margin-top: -${({ theme }) => theme.spaceMap.xl}px;
+  padding-top: 0;
+  padding-bottom: ${({ theme }) => theme.spaceMap.sm}px;
+  padding-left: ${({ theme }) => theme.spaceMap.xxl}px;
+  padding-right: ${({ theme }) => theme.spaceMap.xxl}px;
 
   ${({ theme }) => theme.mediaQueries.md} {
-    margin: 0 0 0 -32px;
+    padding-left: ${({ theme }) => theme.spaceMap.xl}px;
+    padding-right: ${({ theme }) => theme.spaceMap.xl}px;
   }
 `
 
@@ -91,7 +104,31 @@ export const ModalContentStyle = styled.div`
   padding-top: 0;
 
   ${({ theme }) => theme.mediaQueries.md} {
-    padding: ${({ theme }) => theme.spaceMap.lg}px;
+    padding: ${({ theme }) => theme.spaceMap.xl}px;
     padding-top: 0;
   }
+`
+
+export const ModalCloseStyle = styled(ButtonIcon).attrs({
+  icon: <Close />,
+  color: 'secondary',
+  variant: 'ghost',
+  size: 'xs',
+})`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  flex-shrink: 0;
+  border-radius: 50%;
+`
+
+export const ModalBackStyle = styled(ButtonIcon).attrs({
+  icon: <ArrowBack />,
+  color: 'secondary',
+  variant: 'ghost',
+  size: 'xs',
+})`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  flex-shrink: 0;
+  margin: 0;
+  border-radius: 50%;
+  background: transparent !important;
 `

--- a/packages/modal/src/ModalStyles.tsx
+++ b/packages/modal/src/ModalStyles.tsx
@@ -1,41 +1,49 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Close, ArrowBack } from '@lidofinance/icons'
 import { ButtonIcon } from '@lidofinance/button'
 
 export const ModalStyle = styled.div<{ $center: boolean }>`
-  width: 432px;
-  max-width: 100%;
-  font-weight: 500;
-  font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
-  line-height: 1.5em;
-  text-align: ${({ $center }) => ($center ? 'center' : 'left')};
-  border-radius: ${({ theme }) => theme.borderRadiusesMap.xl}px;
-  box-shadow: ${({ theme }) =>
-    `${theme.boxShadows.xxl} ${theme.colors.shadowDark}`};
+  ${({
+    theme: { fontSizesMap, borderRadiusesMap, colors, boxShadows },
+    $center,
+  }) => css`
+    width: 432px;
+    max-width: 100%;
+    font-weight: 500;
+    font-size: ${fontSizesMap.xs}px;
+    line-height: 1.5em;
+    text-align: ${$center ? 'center' : 'left'};
+    border-radius: ${borderRadiusesMap.xl}px;
+    box-shadow: ${boxShadows.xxl} ${colors.shadowDark};
+  `}
 `
 
 export const ModalBaseStyle = styled.div`
-  color: ${({ theme }) => theme.colors.text};
-  background: ${({ theme }) => theme.colors.foreground};
-  border-radius: inherit;
-  position: relative;
-  z-index: 1;
+  ${({ theme: { colors } }) => css`
+    color: ${colors.text};
+    background: ${colors.foreground};
+    border-radius: inherit;
+    position: relative;
+    z-index: 1;
+  `}
 `
 
 export const ModalHeaderStyle = styled.div<{
   $short: boolean
 }>`
-  display: flex;
-  align-items: flex-start;
-  min-height: 32px;
-  margin-bottom: ${({ $short, theme }) => ($short ? -theme.spaceMap.md : 0)}px;
-  padding: ${({ theme }) => theme.spaceMap.xl}px;
-  font-size: ${({ theme }) => theme.fontSizesMap.md}px;
-  line-height: 1.5em;
+  ${({ theme: { spaceMap, fontSizesMap, mediaQueries }, $short }) => css`
+    display: flex;
+    align-items: flex-start;
+    min-height: 32px;
+    margin-bottom: ${$short ? -spaceMap.md : 0}px;
+    padding: ${spaceMap.xl}px;
+    font-size: ${fontSizesMap.md}px;
+    line-height: 1.5em;
 
-  ${({ theme }) => theme.mediaQueries.md} {
-    padding: ${({ theme }) => theme.spaceMap.lg}px;
-  }
+    ${mediaQueries.md} {
+      padding: ${spaceMap.lg}px;
+    }
+  `}
 `
 
 export const ModalTitleStyle = styled.div<{
@@ -44,37 +52,39 @@ export const ModalTitleStyle = styled.div<{
   $withCloseButton: boolean
   $withBackButton: boolean
 }>`
-  font-size: ${({ theme }) => theme.fontSizesMap.sm}px;
-  line-height: 1.5em;
-  font-weight: 700;
-  margin-left: ${({ theme, $center, $withBackButton }) =>
-    $center && !$withBackButton ? theme.spaceMap.xxl : '0'}px;
-  margin-right: ${({ theme, $center, $withCloseButton }) =>
-    $center && !$withCloseButton ? theme.spaceMap.xxl : '0'}px;
-  padding-top: ${({ theme, $withTitleIcon }) =>
-    $withTitleIcon ? theme.spaceMap.sm : '0'}px;
-  padding-left: ${({ theme }) => theme.spaceMap.sm}px;
-  padding-right: ${({ theme }) => theme.spaceMap.sm}px;
-  flex-grow: 1;
-  align-self: center;
+  ${({
+    theme: { fontSizesMap, spaceMap, mediaQueries },
+    $center,
+    $withBackButton,
+    $withCloseButton,
+    $withTitleIcon,
+  }) => css`
+    font-size: ${fontSizesMap.sm}px;
+    line-height: 1.5em;
+    font-weight: 700;
+    margin-left: ${$center && !$withBackButton ? spaceMap.xxl : '0'}px;
+    margin-right: ${$center && !$withCloseButton ? spaceMap.xxl : '0'}px;
+    padding-top: ${$withTitleIcon ? spaceMap.sm : '0'}px;
+    padding-left: ${spaceMap.sm}px;
+    padding-right: ${spaceMap.sm}px;
+    flex-grow: 1;
+    align-self: center;
 
-  ${({ theme }) => theme.mediaQueries.md} {
-    padding-left: ${({ theme }) => theme.spaceMap.xs}px;
-    padding-right: ${({ theme }) => theme.spaceMap.xs}px;
-  }
+    ${mediaQueries.md} {
+      padding-left: ${spaceMap.xs}px;
+      padding-right: ${spaceMap.xs}px;
+    }
+  `}
 `
 
 export const ModalTitleIconStyle = styled.div<{
   $center: boolean
 }>`
-  line-height: 0.7;
-  margin-bottom: ${({ theme }) => theme.spaceMap.md}px;
-
-  ${({ $center }) =>
-    $center &&
-    `
-    display: flex;
-    justify-content: center;
+  ${({ theme: { spaceMap }, $center }) => css`
+    display: ${$center ? 'flex' : 'block'};
+    justify-content: ${$center ? 'center' : 'flex-start'};
+    line-height: 0.7;
+    margin-bottom: ${spaceMap.md}px;
   `}
 `
 
@@ -83,30 +93,34 @@ export const ModalTitleTextStyle = styled.div`
 `
 
 export const ModalSubtitleStyle = styled.div`
-  color: ${({ theme }) => theme.colors.textSecondary};
-  font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
-  font-weight: 400;
-  line-height: 24px;
-  margin-top: -${({ theme }) => theme.spaceMap.xl}px;
-  padding-top: 0;
-  padding-bottom: ${({ theme }) => theme.spaceMap.sm}px;
-  padding-left: ${({ theme }) => theme.spaceMap.xxl}px;
-  padding-right: ${({ theme }) => theme.spaceMap.xxl}px;
+  ${({ theme: { colors, fontSizesMap, spaceMap, mediaQueries } }) => css`
+    color: ${colors.textSecondary};
+    font-size: ${fontSizesMap.xs}px;
+    font-weight: 400;
+    line-height: 24px;
+    margin-top: -${spaceMap.xl}px;
+    padding-top: 0;
+    padding-bottom: ${spaceMap.sm}px;
+    padding-left: ${spaceMap.xxl}px;
+    padding-right: ${spaceMap.xxl}px;
 
-  ${({ theme }) => theme.mediaQueries.md} {
-    padding-left: ${({ theme }) => theme.spaceMap.xl}px;
-    padding-right: ${({ theme }) => theme.spaceMap.xl}px;
-  }
+    ${mediaQueries.md} {
+      padding-left: ${spaceMap.xl}px;
+      padding-right: ${spaceMap.xl}px;
+    }
+  `}
 `
 
 export const ModalContentStyle = styled.div`
-  padding: ${({ theme }) => theme.spaceMap.xxl}px;
-  padding-top: 0;
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    padding: ${({ theme }) => theme.spaceMap.xl}px;
+  ${({ theme: { spaceMap, mediaQueries } }) => css`
+    padding: ${spaceMap.xxl}px;
     padding-top: 0;
-  }
+
+    ${mediaQueries.md} {
+      padding: ${spaceMap.xl}px;
+      padding-top: 0;
+    }
+  `}
 `
 
 export const ModalCloseStyle = styled(ButtonIcon).attrs({

--- a/packages/modal/src/types.tsx
+++ b/packages/modal/src/types.tsx
@@ -9,6 +9,7 @@ export type ModalOverlayOwnProps = LidoComponentProps<
   'div',
   {
     onClose?: () => void
+    onBack?: () => void
   }
 >
 
@@ -18,6 +19,7 @@ export type ModalOverlayInnerProps = ModalOverlayOwnProps & TransitionInnerProps
 export type ModalProps = {
   title?: React.ReactNode
   titleIcon?: React.ReactNode
+  subtitle?: React.ReactNode
   extra?: React.ReactNode
   center?: boolean
   open?: boolean


### PR DESCRIPTION
The new design of the Connect Wallet Modal includes such usage examples of the Modal component:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/1245209/162236320-0ce656f9-d6e0-4db3-b80c-6016cf72e59d.png">

We can see the Back button and the Subtitle area here, which we haven't in the Modal component before.

This PR adds this required elements. Also I decided to adjust some paddings, margins, colors and else.

