### PR TITLE
CI: Missing dependencies of npm plugin for releases

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -17,3 +17,9 @@ plugins:
     spec: "@yarnpkg/plugin-typescript"
 
 yarnPath: .yarn/releases/yarn-3.1.1.cjs
+
+packageExtensions:
+  "@semrel-extra/npm@*":
+    dependencies:
+      "@semantic-release/npm": "^7.0.0"
+      "lodash": "^4.17.15"


### PR DESCRIPTION
Our releases seem to be blocked by npm throttling. For a potential fix, we are updating and/or bringing new dependencies to the project.