### PR TITLE
Fixes founded in solana staking development

### DIFF
--- a/packages/accordion/src/AccordionStyles.tsx
+++ b/packages/accordion/src/AccordionStyles.tsx
@@ -43,7 +43,7 @@ export const AccordionContentStyle = styled.div`
   color: ${({ theme }) => theme.colors.textSecondary};
   padding: ${({ theme }) => theme.spaceMap.xxl}px;
   padding-top: 0;
-  font-weight: 500;
+  font-weight: 400;
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
   line-height: 1.6em;
 

--- a/packages/address/src/AddressStyles.tsx
+++ b/packages/address/src/AddressStyles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 export const AddressStyle = styled.div`
   position: relative;
   display: inline-block;
-  font-weight: 500;
+  font-weight: 400;
 `
 
 export const AddressFullStyle = styled.span`

--- a/packages/block/src/Block.stories.tsx
+++ b/packages/block/src/Block.stories.tsx
@@ -12,6 +12,7 @@ export default {
     children: 'Example content',
     variant: 'flat',
     color: 'foreground',
+    paddingLess: false,
   },
   argTypes: {
     variant: {

--- a/packages/block/src/Block.tsx
+++ b/packages/block/src/Block.tsx
@@ -3,9 +3,22 @@ import { BlockStyle } from './BlockStyles'
 import { BlockProps } from './types'
 
 function Block(props: BlockProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { color = 'foreground', variant = 'flat', ...rest } = props
+  const {
+    color = 'foreground',
+    variant = 'flat',
+    paddingLess = false,
+    ...rest
+  } = props
 
-  return <BlockStyle $color={color} $variant={variant} ref={ref} {...rest} />
+  return (
+    <BlockStyle
+      $color={color}
+      $variant={variant}
+      $paddingLess={paddingLess}
+      ref={ref}
+      {...rest}
+    />
+  )
 }
 
 export default forwardRef(Block)

--- a/packages/block/src/BlockStyles.tsx
+++ b/packages/block/src/BlockStyles.tsx
@@ -5,6 +5,7 @@ import { BlockVariants, BlockColors } from './types'
 type InjectedProps = {
   $variant: BlockVariants
   $color: BlockColors
+  $paddingLess: boolean
   theme: Theme
 }
 
@@ -33,17 +34,22 @@ const variants = {
   `,
 }
 
+const paddings = css`
+  padding: ${({ theme }) => theme.spaceMap.xxl}px;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    padding: ${({ theme }) => theme.spaceMap.lg}px;
+  }
+`
+
 export const BlockStyle = styled.div<InjectedProps>`
   font-weight: 500;
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
   line-height: 1.6em;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.xl}px;
-  padding: ${({ theme }) => theme.spaceMap.xxl}px;
   margin: 0;
 
-  ${({ theme }) => theme.mediaQueries.md} {
-    padding: ${({ theme }) => theme.spaceMap.lg}px;
-  }
+  ${({ $paddingLess }) => !$paddingLess && paddings}
 
   ${({ $variant }) => variants[$variant]}
   ${({ $color }) => colors[$color]}

--- a/packages/block/src/BlockStyles.tsx
+++ b/packages/block/src/BlockStyles.tsx
@@ -43,7 +43,7 @@ const paddings = css`
 `
 
 export const BlockStyle = styled.div<InjectedProps>`
-  font-weight: 500;
+  font-weight: 400;
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
   line-height: 1.6em;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.xl}px;

--- a/packages/block/src/types.tsx
+++ b/packages/block/src/types.tsx
@@ -19,5 +19,6 @@ export type BlockProps = LidoComponentProps<
   {
     color?: BlockColors
     variant?: BlockVariants
+    paddingLess?: boolean
   }
 >

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -23,7 +23,9 @@
     "react"
   ],
   "dependencies": {
+    "@lidofinance/box": "workspace:*",
     "@lidofinance/icons": "workspace:*",
+    "@lidofinance/text": "workspace:*",
     "@lidofinance/theme": "workspace:*",
     "@lidofinance/utils": "workspace:*"
   },

--- a/packages/checkbox/src/Checkbox.stories.tsx
+++ b/packages/checkbox/src/Checkbox.stories.tsx
@@ -31,3 +31,11 @@ export const Controlled: Story<CheckboxProps> = (props) => {
 Controlled.args = {
   checked: true,
 }
+
+export const WithLabel: Story<CheckboxProps> = (props) => {
+  return <Checkbox {...props} />
+}
+
+WithLabel.args = {
+  label: 'Label',
+}

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -5,18 +5,28 @@ import {
   CheckboxInputStyle,
   CheckboxIconStyle,
 } from './CheckboxStyles'
+import { Text } from '@lidofinance/text'
+import { Box } from '@lidofinance/box'
 
 function Checkbox(
   props: CheckboxProps,
   inputRef?: ForwardedRef<HTMLInputElement>
 ) {
-  const { className, style, wrapperRef, children, ...inputProps } = props
+  const { className, style, wrapperRef, children, label, ...inputProps } = props
+  const { disabled } = inputProps
   const wrapperProps = { className, style }
 
   return (
     <CheckboxWrapperStyle {...wrapperProps} ref={wrapperRef}>
       <CheckboxInputStyle type='checkbox' {...inputProps} ref={inputRef} />
       <CheckboxIconStyle />
+      {label && (
+        <Box ml={8}>
+          <Text size='xxs' color={disabled ? 'secondary' : 'default'}>
+            {label}
+          </Text>
+        </Box>
+      )}
     </CheckboxWrapperStyle>
   )
 }

--- a/packages/checkbox/src/CheckboxStyles.tsx
+++ b/packages/checkbox/src/CheckboxStyles.tsx
@@ -3,10 +3,11 @@ import { Check } from '@lidofinance/icons'
 
 export const CheckboxWrapperStyle = styled.label`
   flex-shrink: 0;
-  display: inline-block;
+  display: inline-flex;
   position: relative;
   overflow: hidden;
   line-height: 0;
+  align-items: center;
 `
 
 export const CheckboxIconStyle = styled(Check)`

--- a/packages/checkbox/src/types.ts
+++ b/packages/checkbox/src/types.ts
@@ -6,5 +6,6 @@ export type CheckboxProps = LidoComponentProps<
   {
     wrapperRef?: React.RefObject<HTMLLabelElement>
     children?: never
+    label?: string
   }
 >

--- a/packages/data-table/src/DataTableStyles.tsx
+++ b/packages/data-table/src/DataTableStyles.tsx
@@ -6,7 +6,7 @@ export const DataTableStyle = styled.div``
 export const DataTableRowStyle = styled.div`
   display: flex;
   margin: ${({ theme }) => theme.spaceMap.md}px 0;
-  font-weight: 500;
+  font-weight: 400;
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
   line-height: 1.6em;
 

--- a/packages/input/src/InputStyles.ts
+++ b/packages/input/src/InputStyles.ts
@@ -113,7 +113,7 @@ const contentVariants = {
 }
 
 export const InputContentStyle = styled.span<{ $variant: InputVariants }>`
-  font-weight: 500;
+  font-weight: 400;
   font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
   display: flex;
   flex-grow: 1;
@@ -184,7 +184,7 @@ export const InputStyle = styled.input<{
 }>`
   width: 100%;
   font-family: inherit;
-  font-weight: 500;
+  font-weight: 400;
   font-size: 1em;
   line-height: 1.43em;
   padding: 0;
@@ -232,7 +232,7 @@ export const InputMessageStyle = styled.span<{
   position: absolute;
   top: 100%;
   line-height: 1.6em;
-  font-weight: 500;
+  font-weight: 400;
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.sm}px;
   padding: 6px 10px;

--- a/packages/modal/src/ModalStyles.tsx
+++ b/packages/modal/src/ModalStyles.tsx
@@ -9,7 +9,7 @@ export const ModalStyle = styled.div<{ $center: boolean }>`
   }) => css`
     width: 432px;
     max-width: 100%;
-    font-weight: 500;
+    font-weight: 400;
     font-size: ${fontSizesMap.xs}px;
     line-height: 1.5em;
     text-align: ${$center ? 'center' : 'left'};

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import styled from 'styled-components'
 
 import { ArrowLeft, ArrowRight } from '@lidofinance/icons'
@@ -38,6 +38,10 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     () => getShowingPages(pagesCount, currentPage, siblingCount),
     [pagesCount, currentPage, siblingCount]
   )
+
+  useEffect(() => {
+    setCurrPage((page) => (page !== activePage ? activePage : page))
+  }, [activePage])
 
   if (pagesCount <= 0) {
     return null

--- a/packages/popover/src/PopoverStyles.ts
+++ b/packages/popover/src/PopoverStyles.ts
@@ -25,7 +25,7 @@ export const PopoverStyle = styled(PopoverRoot)`
   color: ${({ theme }) => theme.colors.text};
   font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
   line-height: 1.5em;
-  font-weight: 500;
+  font-weight: 400;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.lg}px;
   box-shadow: ${({ theme }) =>
     `${theme.boxShadows.xs} ${theme.colors.shadowLight}`};

--- a/packages/popup-menu/src/PopupMenuItemStyles.ts
+++ b/packages/popup-menu/src/PopupMenuItemStyles.ts
@@ -59,7 +59,7 @@ const variants = {
     padding: 18px 0;
     font-size: ${({ theme }) => theme.fontSizesMap.xs}px;
     line-height: 1.4em;
-    font-weight: 500;
+    font-weight: 400;
   `,
 }
 

--- a/packages/table/src/styles.tsx
+++ b/packages/table/src/styles.tsx
@@ -67,7 +67,7 @@ export const TheadStyle = styled.thead`
 export const TfootStyle = styled.tfoot``
 
 export const TrStyle = styled.tr`
-  font-weight: 500;
+  font-weight: 400;
   font-size: ${({ theme }) => theme.fontSizesMap.xxs}px;
   line-height: 1.6em;
 `

--- a/packages/tooltip/src/TooltipStyles.ts
+++ b/packages/tooltip/src/TooltipStyles.ts
@@ -7,7 +7,7 @@ export const TooltipPopoverStyle = styled(Popover)`
   color: ${({ theme }) => theme.colors.accentContrast};
   font-size: ${({ theme }) => theme.fontSizesMap.xxxs}px;
   line-height: 1.8em;
-  font-weight: 500;
+  font-weight: 400;
   max-width: 256px;
   border-radius: ${({ theme }) => theme.borderRadiusesMap.md}px;
   box-shadow: ${({ theme }) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3782,7 +3782,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lidofinance/checkbox@workspace:packages/checkbox"
   dependencies:
+    "@lidofinance/box": "workspace:*"
     "@lidofinance/icons": "workspace:*"
+    "@lidofinance/text": "workspace:*"
     "@lidofinance/theme": "workspace:*"
     "@lidofinance/utils": "workspace:*"
     "@storybook/react": 6.3.7


### PR DESCRIPTION
- [changed font-weight: 500 to 400 everywhere](https://github.com/lidofinance/ui/commit/5a58e6ada63b80f9d5ed1eee900d5a0f7cfa0589) agreed with the designer, also because of [makets](https://www.figma.com/file/0j4EJ3Ra7OPBeEKLXFQiGM/LIDO-Design-System?node-id=11311%3A356), there everywhere is 400
- added ability adding label for checkbox, for better UX
- added `paddingLess` props for block component, because of frequent need
- also small fix for pagination component