### PR TITLE
feat(input): add a warning prop for input and textarea

### DIFF
--- a/packages/input/src/Input.stories.tsx
+++ b/packages/input/src/Input.stories.tsx
@@ -169,6 +169,15 @@ WithError.argTypes = {
   },
 }
 
+export const WithWarning: Story<InputProps> = (props) => <Input {...props} />
+
+WithWarning.args = {
+  fullwidth: true,
+  defaultValue: '10',
+  label: 'Token amount',
+  warning: 'Amount may be insufficient.',
+}
+
 const Success = styled.span`
   font-weight: 600;
   font-size: ${({ theme }) => theme.fontSizesMap.xs}px;

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -14,6 +14,7 @@ function Input(props: InputProps, ref?: ForwardedRef<HTMLInputElement>) {
   const {
     label,
     error,
+    warning,
     success,
     active = false,
     fullwidth = false,
@@ -36,6 +37,8 @@ function Input(props: InputProps, ref?: ForwardedRef<HTMLInputElement>) {
 
   const hasError = !!error
   const hasErrorMessage = hasError && typeof error !== 'boolean'
+  const hasWarning = !hasError && !!warning // `error` overrides `warning`
+  const hasWarningMessage = hasWarning && typeof warning !== 'boolean'
   const hasSuccess = !!success && !error
   const hasSuccessMessage = hasSuccess && typeof success !== 'boolean'
 
@@ -45,6 +48,7 @@ function Input(props: InputProps, ref?: ForwardedRef<HTMLInputElement>) {
   return (
     <InputWrapperStyle
       $error={hasError}
+      $warning={hasWarning}
       $active={active}
       $disabled={disabled}
       $fullwidth={fullwidth}
@@ -73,6 +77,11 @@ function Input(props: InputProps, ref?: ForwardedRef<HTMLInputElement>) {
       {hasErrorMessage && (
         <InputMessageStyle $variant='error' $bordered>
           {error}
+        </InputMessageStyle>
+      )}
+      {hasWarningMessage && (
+        <InputMessageStyle $variant='warning' $bordered>
+          {warning}
         </InputMessageStyle>
       )}
       {hasSuccessMessage && (

--- a/packages/input/src/InputStyles.ts
+++ b/packages/input/src/InputStyles.ts
@@ -5,6 +5,7 @@ import {
   labelFocusCSS,
   labelErrorCSS,
   InputLabelStyle,
+  labelWarningCSS,
 } from './LabelStyles'
 
 const statesCSS = css`
@@ -47,6 +48,18 @@ const errorCSS = css`
   }
 `
 
+const warningCSS = css`
+  &,
+  &:hover,
+  &:focus-within {
+    border-color: ${({ theme }) => theme.colors.warning};
+
+    ${InputLabelStyle} {
+      ${labelWarningCSS}
+    }
+  }
+`
+
 const wrapperColors = {
   default: css<{ $disabled: boolean }>`
     background: ${({ theme }) => theme.colors.controlBg};
@@ -80,6 +93,7 @@ const wrapperColors = {
 
 export const InputWrapperStyle = styled.label<{
   $error: boolean
+  $warning: boolean
   $active: boolean
   $disabled: boolean
   $fullwidth: boolean
@@ -100,6 +114,7 @@ export const InputWrapperStyle = styled.label<{
   ${({ $disabled }) => ($disabled ? '' : statesCSS)}
 
   ${({ $active }) => ($active ? activeCSS : '')}
+  ${({ $warning }) => ($warning ? warningCSS : '')}
   ${({ $error }) => ($error ? errorCSS : '')}
 `
 
@@ -217,6 +232,12 @@ const messageVariants = {
   error: css`
     background: ${({ theme }) => theme.colors.error};
     color: ${({ theme }) => theme.colors.errorContrast};
+    box-shadow: ${({ theme }) =>
+      `${theme.boxShadows.sm} ${theme.colors.shadowLight}`};
+  `,
+  warning: css`
+    background: ${({ theme }) => theme.colors.warning};
+    color: ${({ theme }) => theme.colors.warningContrast};
     box-shadow: ${({ theme }) =>
       `${theme.boxShadows.sm} ${theme.colors.shadowLight}`};
   `,

--- a/packages/input/src/LabelStyles.ts
+++ b/packages/input/src/LabelStyles.ts
@@ -33,6 +33,10 @@ export const labelErrorCSS = css`
   color: ${({ theme }) => theme.colors.error};
 `
 
+export const labelWarningCSS = css`
+  color: ${({ theme }) => theme.colors.warning};
+`
+
 export const InputLabelStyle = styled.span`
   position: absolute;
   left: 0;

--- a/packages/input/src/Textarea.tsx
+++ b/packages/input/src/Textarea.tsx
@@ -12,6 +12,7 @@ function Textarea(props: TextareaProps, ref?: ForwardedRef<HTMLInputElement>) {
   const {
     label,
     error,
+    warning,
     success,
     active = false,
     fullwidth = false,
@@ -32,12 +33,15 @@ function Textarea(props: TextareaProps, ref?: ForwardedRef<HTMLInputElement>) {
 
   const hasError = !!error
   const hasErrorMessage = hasError && typeof error !== 'boolean'
+  const hasWarning = !hasError && !!warning // `error` overrides `warning`
+  const hasWarningMessage = hasWarning && typeof warning !== 'boolean'
   const hasSuccess = !!success && !error
   const hasSuccessMessage = hasSuccess && typeof success !== 'boolean'
 
   return (
     <InputWrapperStyle
       $error={hasError}
+      $warning={hasWarning}
       $active={active}
       $disabled={disabled}
       $fullwidth={fullwidth}
@@ -63,6 +67,11 @@ function Textarea(props: TextareaProps, ref?: ForwardedRef<HTMLInputElement>) {
       {hasErrorMessage && (
         <InputMessageStyle $variant='error' $bordered>
           {error}
+        </InputMessageStyle>
+      )}
+      {hasWarningMessage && (
+        <InputMessageStyle $variant='warning' $bordered>
+          {warning}
         </InputMessageStyle>
       )}
       {hasSuccessMessage && (

--- a/packages/input/src/types.ts
+++ b/packages/input/src/types.ts
@@ -1,8 +1,10 @@
 import { LidoComponentProps } from '@lidofinance/utils'
+import React from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export enum InputMessageVariant {
   error,
+  warning,
   success,
 }
 export type InputMessageVariants = keyof typeof InputMessageVariant
@@ -33,6 +35,7 @@ export type InputColors = keyof typeof InputColor
 type CommonProps = {
   label?: React.ReactNode
   error?: React.ReactNode | boolean
+  warning?: React.ReactNode | boolean
   success?: React.ReactNode | boolean
   variant?: InputVariants
   color?: InputColors


### PR DESCRIPTION
This PR adds a `warning` prop for `Input` component. It is used for non-critical messages warning the user that the input value can possibly be invalid.

The prop behaves the same as `error` but uses `warning` color. The `error` prop has a priority over `warning` and it will override it.

Design link: https://www.figma.com/file/66L3gxbUxVhqhXQjy4xzOz/Web?node-id=13522%3A65912

Preview
<img width="424" alt="image" src="https://user-images.githubusercontent.com/39704351/178244424-956656ec-a112-41ad-9785-14c894151a37.png">
