### PR TITLE
fix(icons): dummy release

### DIFF
--- a/packages/icons/src/Icon.stories.tsx
+++ b/packages/icons/src/Icon.stories.tsx
@@ -181,12 +181,12 @@ export const CryptoWallets: Story = () => {
     MathWalletCircleInversion,
     Coin98Circle,
     Ambire,
+    Zengo,
     Blochainwallet,
     BlochainwalletInversion,
     Exodus,
     OperaWallet,
     Unstoppabledomains,
-    Zengo,
   }) as IconVariants[]
 
   return (


### PR DESCRIPTION
Reason: github workflow with npm publishing failed, semantic-release do not allow to re-publish the package.