### PR TITLE
Using npm token from environment protection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: deploy
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -9,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
     env:
       NODE_OPTIONS: --max_old_space_size=4096
     steps:
@@ -16,19 +16,25 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
+
       - name: Install Dependencies
         run: yarn install --immutable
+
       - name: Run lint
         run: yarn lint
+
       - name: Build Components
         run: yarn build
+
       - name: Run tests
         run: yarn test
+
       - name: Publish to NPM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,6 +43,7 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           yarn release
+
       - name: Build Storybook
         run: yarn build-storybook
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,23 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          node-version: '16'
           cache: 'yarn'
+
       - name: Install dependencies
         run: yarn install --immutable
+
       - name: Run lint
         run: yarn lint
+
       - name: Build Components
         run: yarn build
+
       - name: Run tests
         run: yarn test


### PR DESCRIPTION
# Description

- It shouldn't be possible to trigger publish from any branch
- NPM_TOKEN should only be available in `main` branch