### PR TITLE
Fix build by rolling back node

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '14'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '14'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
# Description

`npm version ...` doesn't actually work with node v16 & yarn workspace, but only works with node v14

<img width="610" alt="image" src="https://user-images.githubusercontent.com/103929444/205932974-68c77063-e55c-447a-a453-aa6e984e494c.png">

It is run as part of release script https://github.com/lidofinance/ui/actions/runs/3582347365/jobs/6026461054

This is more like temporary fix, need to figure out how to publish normally
