### PR TITLE
fix: fix input style for success variant

### DIFF
--- a/packages/input/InputStyles.ts
+++ b/packages/input/InputStyles.ts
@@ -241,7 +241,10 @@ const messageVariants = {
       var(--lido-color-shadowLight);
   `,
   success: css`
-    color: var(--lido-color-success);
+    background: var(--lido-color-success);
+    color: var(--lido-color-successContrast);
+    box-shadow: ${({ theme }) => theme.boxShadows.sm}
+      var(--lido-color-shadowLight);
   `,
 }
 


### PR DESCRIPTION
Old style:
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/20888859/228543085-ced63f83-a60e-4ac8-9b20-de9156d84cf1.png">
Fixed style: 
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/20888859/228543248-9c2f4047-0eee-4a37-ae64-40e2c65a0825.png">

Made by analogy with warning and error
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/20888859/228543882-3234b6a0-f354-4409-97f6-19954d425bc5.png">

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/20888859/228543951-c0addaaf-a17e-4ead-9444-a5846fbe4c64.png">


