### PR TITLE
Fix: input autofilled text color

### DIFF
--- a/packages/input/InputStyles.ts
+++ b/packages/input/InputStyles.ts
@@ -164,10 +164,12 @@ const inputColors = {
     &:-webkit-autofill {
       box-shadow: 0 0 0 100px var(--lido-color-controlBg) inset !important;
       color: var(--lido-color-text) !important;
+      -webkit-text-fill-color: var(--lido-color-text) !important;
     }
 
     &:-internal-autofill-selected {
       color: var(--lido-color-text) !important;
+      -webkit-text-fill-color: var(--lido-color-text) !important;
     }
   `,
   accent: css`
@@ -187,10 +189,12 @@ const inputColors = {
     &:-webkit-autofill {
       box-shadow: 0 0 0 100px var(--lido-color-accentControlBg) inset !important;
       color: var(--lido-color-accentContrast) !important;
+      -webkit-text-fill-color: var(--lido-color-accentContrast) !important;
     }
 
     &:-internal-autofill-selected {
       color: var(--lido-color-accentContrast) !important;
+      -webkit-text-fill-color: var(--lido-color-accentContrast) !important;
     }
   `,
 }


### PR DESCRIPTION
Fixing a problem with a text color in input that appears when selecting data from input saved autofill suggestion.

<img width="304" alt="image" src="https://github.com/lidofinance/ui/assets/7289992/627c8f16-cdb5-4e27-9275-cdb1d7317549">
