### PR TITLE
Apply postcss layers plugin during build

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,11 +1,11 @@
 /** @type {import('postcss-load-config').Config} */
-module.exports = {
+module.exports = (ctx) => ({
   plugins: {
+    'postcss-custom-media': {},
     '@csstools/postcss-global-data': {
       files: ['packages/theme/base/breakpoints.css'],
     },
-    'postcss-custom-media': {},
+    '@csstools/postcss-cascade-layers': ctx.env === 'production' ? {} : false,
     'postcss-nesting': {},
-    '@csstools/postcss-cascade-layers': {},
   },
-}
+})


### PR DESCRIPTION
### Description

We can use browser layers during development:

<img width="1095" alt="image" src="https://github.com/lidofinance/ui/assets/103929444/82c261be-a6f6-497e-a78d-929e1d1f1ab3">

Because postcss plugin doesn't work on separate files:

![image](https://github.com/lidofinance/ui/assets/103929444/f200eb3e-c73e-4062-9c7b-93b3b16ff856)

But we can still apply it during production build once there are all files. e.g. final selector for `modalButton` is more specific than `button` selector:

```
._modalButton_1qzmn_4:not(#_\#_1qzmn_1):not(#\#):not(#\#) {...}

._button_8csc7_4:not(#\#) {...}
```