### PR TITLE
Moved props destruction to params level & fixed react types usage

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -12,7 +12,7 @@
       }
     ],
     "@babel/preset-typescript",
-    "@babel/preset-react"
+    ["@babel/preset-react", { "runtime": "automatic" }]
   ],
   "plugins": []
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   rules: {
     'prettier/prettier': 'error',
     'react/prop-types': 'off',
+    'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,29 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  cacheDirectory: '.jest-cache',
-  coverageDirectory: '.jest-coverage',
-  // forked from default
-  // https://jestjs.io/docs/configuration#testmatch-arraystring
-  testMatch: [
-    '**/__tests__/**/*.[jt]s',
-    '**/__tests__/**/*.[jt]sx',
-    '**/?(*.)+(spec|test).[jt]s',
-    '**/?(*.)+(spec|test).[jt]sx',
-  ],
-  collectCoverageFrom: ['packages/**/*'],
-  coverageReporters: ['html', 'text'],
-  coverageThreshold: {
-    global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
-    },
-  },
-  transform: {
-    '^.+\\.((js|ts)x?)$': ['@swc/jest'],
-  },
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
   moduleNameMapper: {
-    '^@lidofinance/(.*)$': '<rootDir>/packages/$1/src',
+    '^@lidofinance/(.*)$': '<rootDir>/packages/$1',
   },
-  testEnvironment: 'jest-environment-jsdom',
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@swc/core": "^1.2.245",
     "@swc/jest": "^0.2.22",
     "@testing-library/react": "^13.3.0",
-    "@types/jest": "^28.1.8",
+    "@types/jest": "^29.5.3",
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",
     "@types/react-is": "17.0.2",
@@ -120,6 +120,7 @@
     "stylelint": "^15.10.2",
     "stylelint-config-standard": "^34.0.0",
     "stylelint-prettier": "^4.0.2",
+    "ts-jest": "^29.1.1",
     "tslib": "2.3.1",
     "typescript": "4.8",
     "zx": "^7.0.8"

--- a/packages/accordion/Accordion.tsx
+++ b/packages/accordion/Accordion.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { AccordionProps } from './types'
 import {
   AccordionStyle,
@@ -9,9 +9,13 @@ import {
 } from './AccordionStyles'
 import { useExpanded } from './useExpanded'
 
-function Accordion(props: AccordionProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { defaultExpanded, summary, children, ...rest } = props
-  const { toggleProps, collapseProps, isExpanded } = useExpanded(props)
+function Accordion(
+  { defaultExpanded, summary, children, ...rest }: AccordionProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
+  const { toggleProps, collapseProps, isExpanded } = useExpanded({
+    defaultExpanded,
+  })
 
   return (
     <AccordionStyle {...rest} ref={ref}>

--- a/packages/accordion/types.ts
+++ b/packages/accordion/types.ts
@@ -1,11 +1,11 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React from 'react'
+import { ReactNode } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export type AccordionProps = LidoComponentProps<
   'div',
   {
     defaultExpanded?: boolean
-    summary: React.ReactNode
+    summary: ReactNode
   }
 >

--- a/packages/accordion/useExpanded.ts
+++ b/packages/accordion/useExpanded.ts
@@ -6,7 +6,7 @@ import {
   GetTogglePropsOutput,
 } from 'react-collapsed/dist/types'
 
-type UseExpanded = (props: AccordionProps) => {
+type UseExpanded = (props: Pick<AccordionProps, 'defaultExpanded'>) => {
   toggleProps: GetTogglePropsOutput
   collapseProps: GetCollapsePropsOutput
   isExpanded: boolean

--- a/packages/address/Address.tsx
+++ b/packages/address/Address.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { AddressProps } from './types'
 import {
   AddressStyle,
@@ -7,9 +7,10 @@ import {
 } from './AddressStyles'
 import { trimAddress } from './trimAddress'
 
-function Address(props: AddressProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { symbols = 3, address, ...rest } = props
-
+function Address(
+  { symbols = 3, address, ...rest }: AddressProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <AddressStyle {...rest} ref={ref}>
       <AddressFullStyle>{address}</AddressFullStyle>

--- a/packages/addressBadge/AddressBadge.tsx
+++ b/packages/addressBadge/AddressBadge.tsx
@@ -1,13 +1,12 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { useBreakpoint } from '@lidofinance/hooks'
 import { AddressBadgeStyle } from './AddressBadgeStyles'
 import { AddressBadgeProps } from './types'
 
 function AddressBadge(
-  props: AddressBadgeProps,
+  { address, symbolsMobile = 3, symbolsDesktop = 6 }: AddressBadgeProps,
   ref?: ForwardedRef<HTMLDivElement>,
 ) {
-  const { address, symbolsMobile = 3, symbolsDesktop = 6 } = props
   const isMobile = useBreakpoint('md')
 
   return (

--- a/packages/block/Block.tsx
+++ b/packages/block/Block.tsx
@@ -1,15 +1,16 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { BlockStyle } from './BlockStyles'
 import { BlockProps } from './types'
 
-function Block(props: BlockProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const {
+function Block(
+  {
     color = 'foreground',
     variant = 'flat',
     paddingLess = false,
     ...rest
-  } = props
-
+  }: BlockProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <BlockStyle
       $color={color}

--- a/packages/button/Button.test.tsx
+++ b/packages/button/Button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render } from '@testing-library/react'
 import { ThemeProvider, themeDefault } from '@lidofinance/theme'
 import 'jest-styled-components'

--- a/packages/button/Button.tsx
+++ b/packages/button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import {
   ButtonStyle,
   ButtonContentStyle,
@@ -15,8 +15,8 @@ const loaderSizes = {
   lg: 'medium',
 } as const
 
-function Button(props: ButtonProps, ref?: ForwardedRef<HTMLButtonElement>) {
-  const {
+function Button(
+  {
     size = 'md',
     variant = 'filled',
     color = 'primary',
@@ -28,9 +28,10 @@ function Button(props: ButtonProps, ref?: ForwardedRef<HTMLButtonElement>) {
     disabled,
     children,
     ...rest
-  } = props
-
-  const { handleClick, ripple } = useRipple(props)
+  }: ButtonProps,
+  ref?: ForwardedRef<HTMLButtonElement>,
+) {
+  const { handleClick, ripple } = useRipple({ onClick })
   const loaderSize = loaderSizes[size]
 
   return (

--- a/packages/button/ButtonIcon.tsx
+++ b/packages/button/ButtonIcon.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import {
   ButtonWrapperStyle,
   ButtonIconStyle,
@@ -8,10 +8,9 @@ import { ButtonIconProps } from './types'
 import Button from './Button'
 
 function ButtonIcon(
-  props: ButtonIconProps,
+  { icon, children, ...rest }: ButtonIconProps,
   ref?: ForwardedRef<HTMLButtonElement>,
 ) {
-  const { icon, children, ...rest } = props
   const hasNoChildren = !children
 
   return (

--- a/packages/button/useRipple.tsx
+++ b/packages/button/useRipple.tsx
@@ -1,17 +1,17 @@
-import React, { useCallback, useState } from 'react'
+import { MouseEvent, ReactNode, useCallback, useState } from 'react'
 import { ButtonProps } from './types'
 import { ButtonRippleStyle } from './ButtonStyles'
 
-type UseRipple = (props: ButtonProps) => {
-  ripple: React.ReactNode
-  handleClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+type UseRipple = (props: Pick<ButtonProps, 'onClick'>) => {
+  ripple: ReactNode
+  handleClick: (event: MouseEvent<HTMLButtonElement>) => void
 }
 
 export const useRipple: UseRipple = ({ onClick }) => {
-  const [ripple, setRipple] = useState<React.ReactNode | null>(null)
+  const [ripple, setRipple] = useState<ReactNode | null>(null)
 
   const handleClick = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    (event: MouseEvent<HTMLButtonElement>) => {
       const button = event.currentTarget
       const rect = button.getBoundingClientRect()
       const diameter = Math.max(button.clientWidth, button.clientHeight)

--- a/packages/checkbox/Checkbox.tsx
+++ b/packages/checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { CheckboxProps } from './types'
 import {
   CheckboxWrapperStyle,
@@ -9,16 +9,25 @@ import { Text } from '@lidofinance/text'
 import { Box } from '@lidofinance/box'
 
 function Checkbox(
-  props: CheckboxProps,
+  {
+    className,
+    style,
+    wrapperRef,
+    disabled,
+    children,
+    label,
+    ...rest
+  }: CheckboxProps,
   inputRef?: ForwardedRef<HTMLInputElement>,
 ) {
-  const { className, style, wrapperRef, children, label, ...inputProps } = props
-  const { disabled } = inputProps
-  const wrapperProps = { className, style }
-
   return (
-    <CheckboxWrapperStyle {...wrapperProps} ref={wrapperRef}>
-      <CheckboxInputStyle type='checkbox' {...inputProps} ref={inputRef} />
+    <CheckboxWrapperStyle className={className} style={style} ref={wrapperRef}>
+      <CheckboxInputStyle
+        type='checkbox'
+        disabled={disabled}
+        ref={inputRef}
+        {...rest}
+      />
       <CheckboxIconStyle />
       {label && (
         <Box ml={8}>

--- a/packages/checkbox/types.ts
+++ b/packages/checkbox/types.ts
@@ -1,11 +1,11 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React from 'react'
+import { RefObject } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export type CheckboxProps = LidoComponentProps<
   'input',
   {
-    wrapperRef?: React.RefObject<HTMLLabelElement>
+    wrapperRef?: RefObject<HTMLLabelElement>
     children?: never
     label?: string
   }

--- a/packages/chip/Chip.stories.tsx
+++ b/packages/chip/Chip.stories.tsx
@@ -24,7 +24,6 @@ export default {
 export const Basic: Story = (props, options) => (
   <Chip
     {...props}
-    // @ts-expect-error fix later
     onClick={options.args.interactive ? () => void 0 : undefined}
   />
 )

--- a/packages/chip/Chip.tsx
+++ b/packages/chip/Chip.tsx
@@ -1,10 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { ChipProps } from './types'
 import { ChipWrapperStyle } from './ChipStyles'
 
-function Chip(props: ChipProps, ref?: ForwardedRef<HTMLInputElement>) {
-  const { children, onClick, variant = 'positive', ...rest } = props
-
+function Chip(
+  { children, onClick, variant = 'positive', ...rest }: ChipProps,
+  ref?: ForwardedRef<HTMLInputElement>,
+) {
   return (
     <ChipWrapperStyle
       $interactive={!!onClick}

--- a/packages/chip/types.ts
+++ b/packages/chip/types.ts
@@ -1,5 +1,5 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React from 'react'
+import { RefObject } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export enum ChipVariant {
@@ -14,7 +14,7 @@ export type ChipVariants = keyof typeof ChipVariant
 export type ChipProps = LidoComponentProps<
   'div',
   {
-    wrapperRef?: React.RefObject<HTMLLabelElement>
+    wrapperRef?: RefObject<HTMLLabelElement>
     variant?: ChipVariants
   }
 >

--- a/packages/container/Container.tsx
+++ b/packages/container/Container.tsx
@@ -1,10 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { ContainerStyle } from './ContainerStyles'
 import { ContainerProps } from './types'
 
-function Container(props: ContainerProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { size = 'full', ...rest } = props
-
+function Container(
+  { size = 'full', ...rest }: ContainerProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return <ContainerStyle $size={size} ref={ref} {...rest} />
 }
 

--- a/packages/content-theme/content-theme.tsx
+++ b/packages/content-theme/content-theme.tsx
@@ -1,7 +1,5 @@
-import React, { FC } from 'react'
-
+import { FC } from 'react'
 import { ContentThemeOnlyDark, ContentThemeOnlyLight } from './styles'
-
 import { ContentThemeProps } from './types'
 
 export const ContentTheme: FC<ContentThemeProps> = (

--- a/packages/content-theme/types.ts
+++ b/packages/content-theme/types.ts
@@ -1,10 +1,10 @@
-import React from 'react'
 import { LidoComponentProps } from '@lidofinance/utils'
+import { ReactElement } from 'react'
 
 export type ContentThemeProps = LidoComponentProps<
   'div',
   {
-    darkContent: React.ReactElement
-    lightContent: React.ReactElement
+    darkContent: ReactElement
+    lightContent: ReactElement
   }
 >

--- a/packages/cookie-theme-toggler/cookie-theme-toggler.tsx
+++ b/packages/cookie-theme-toggler/cookie-theme-toggler.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import {
   CookieThemeTogglerStyle,
   CookieThemeTogglerDarkIcon,

--- a/packages/cookies-tooltip/cookies-tooltip.tsx
+++ b/packages/cookies-tooltip/cookies-tooltip.tsx
@@ -1,8 +1,7 @@
-import React, { FC, useEffect, useState, useCallback } from 'react'
+import { FC, useEffect, useState, useCallback } from 'react'
 import { Cookie, CookieInverse } from '@lidofinance/icons'
 import { ContentTheme } from '@lidofinance/content-theme'
 import { getCrossDomainCookieClientSide } from '@lidofinance/utils'
-
 import {
   Wrap,
   Box,

--- a/packages/data-table/DataTable.stories.tsx
+++ b/packages/data-table/DataTable.stories.tsx
@@ -12,9 +12,7 @@ export default {
 
 export const Base: Story<
   DataTableProps & Pick<DataTableRowProps, 'loading'>
-> = (props) => {
-  const { loading, ...rest } = props
-
+> = ({ loading, ...rest }) => {
   return (
     <div style={{ width: 300 }}>
       <DataTable {...rest}>

--- a/packages/data-table/DataTable.tsx
+++ b/packages/data-table/DataTable.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { InlineLoader } from '@lidofinance/loaders'
 import { Tooltip } from '@lidofinance/tooltip'
 import {
@@ -17,17 +17,16 @@ function DataTable(props: DataTableProps, ref?: ForwardedRef<HTMLDivElement>) {
 export default forwardRef(DataTable)
 
 export const DataTableRow = forwardRef(function DataTableRow(
-  props: DataTableRowProps,
-  ref?: ForwardedRef<HTMLDivElement>,
-) {
-  const {
+  {
     title,
     loading = false,
     highlight = false,
     help,
     children,
     ...rest
-  } = props
+  }: DataTableRowProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   const hasHelper = !!help
 
   return (

--- a/packages/data-table/types.tsx
+++ b/packages/data-table/types.tsx
@@ -1,5 +1,5 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React from 'react'
+import { ReactNode } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export type DataTableProps = LidoComponentProps<'div'>
@@ -7,8 +7,8 @@ export type DataTableProps = LidoComponentProps<'div'>
 export type DataTableRowProps = LidoComponentProps<
   'div',
   {
-    title: React.ReactNode
-    help?: React.ReactNode
+    title: ReactNode
+    help?: ReactNode
     loading?: boolean
     highlight?: boolean
   }

--- a/packages/divider/Divider.tsx
+++ b/packages/divider/Divider.tsx
@@ -1,10 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { DividerStyle } from './DividerStyles'
 import { DividerProps } from './types'
 
-function Divider(props: DividerProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { type = 'horizontal', indents, children, ...rest } = props
-
+function Divider(
+  { type = 'horizontal', indents, children, ...rest }: DividerProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return <DividerStyle $type={type} $indents={indents} ref={ref} {...rest} />
 }
 

--- a/packages/heading/Heading.tsx
+++ b/packages/heading/Heading.tsx
@@ -1,34 +1,33 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { HeadingStyle, H1Style, H2Style, H3Style } from './HeadingStyles'
 import { HeadingProps, HProps } from './types'
 
-function Heading(props: HeadingProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { size = 'md', color = 'text', ...rest } = props
+function Heading(
+  { size = 'md', color = 'text', ...rest }: HeadingProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return <HeadingStyle $size={size} $color={color} ref={ref} {...rest} />
 }
 
 export default forwardRef(Heading)
 
 export const H1 = forwardRef(function H1(
-  props: HProps<'h1'>,
+  { color = 'text', ...rest }: HProps<'h1'>,
   ref?: ForwardedRef<HTMLHeadingElement>,
 ) {
-  const { color = 'text', ...rest } = props
   return <H1Style $color={color} ref={ref} {...rest} />
 })
 
 export const H2 = forwardRef(function H2(
-  props: HProps<'h2'>,
+  { color = 'text', ...rest }: HProps<'h2'>,
   ref?: ForwardedRef<HTMLHeadingElement>,
 ) {
-  const { color = 'text', ...rest } = props
   return <H2Style $color={color} ref={ref} {...rest} />
 })
 
 export const H3 = forwardRef(function H3(
-  props: HProps<'h3'>,
+  { color = 'text', ...rest }: HProps<'h3'>,
   ref?: ForwardedRef<HTMLHeadingElement>,
 ) {
-  const { color = 'text', ...rest } = props
   return <H3Style $color={color} ref={ref} {...rest} />
 })

--- a/packages/hooks/useMergeRefs.ts
+++ b/packages/hooks/useMergeRefs.ts
@@ -1,10 +1,10 @@
+import { ForwardedRef, MutableRefObject } from 'react'
 import { useMergeRefs as useCallbackMergeRefs } from 'use-callback-ref'
-import React from 'react'
 
 export const useMergeRefs = <T extends HTMLElement>(
-  refs: (React.ForwardedRef<T | null> | undefined)[],
-): React.MutableRefObject<T | null> => {
+  refs: (ForwardedRef<T | null> | undefined)[],
+): MutableRefObject<T | null> => {
   return useCallbackMergeRefs(
-    refs.filter((ref): ref is React.ForwardedRef<T> => !!ref),
+    refs.filter((ref): ref is ForwardedRef<T> => !!ref),
   )
 }

--- a/packages/hooks/useOutsideClick.ts
+++ b/packages/hooks/useOutsideClick.ts
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import { RefObject, useCallback, useEffect, useRef } from 'react'
 
 export const useOutsideClick = <T extends HTMLDivElement>(
   callback?: () => void,
 ): {
-  ref: React.RefObject<T>
+  ref: RefObject<T>
 } => {
   const ref = useRef<T>(null)
 

--- a/packages/icons/Icon.stories.tsx
+++ b/packages/icons/Icon.stories.tsx
@@ -9,8 +9,10 @@ export default {
   title: 'Images/Icons',
 } as Meta
 
-export const Base: Story<{ color: string; type: IconVariants }> = (props) => {
-  const { color, type } = props
+export const Base: Story<{ color: string; type: IconVariants }> = ({
+  color,
+  type,
+}) => {
   const Component = components[type]
 
   return <Component style={{ fill: color || `var(--lido-color-text)` }} />

--- a/packages/identicon/Identicon.tsx
+++ b/packages/identicon/Identicon.tsx
@@ -1,15 +1,20 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { IdenticonProps } from './types'
 import { IdenticonStyle } from './IdenticonStyles'
 import Jazzicon, { jsNumberForAddress } from 'react-jazzicon'
 
-function Identicon(props: IdenticonProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { diameter = 24, address, paperStyles, svgStyles, ...rest } = props
-  const iconProps = { diameter, paperStyles, svgStyles }
-
+function Identicon(
+  { diameter = 24, address, paperStyles, svgStyles, ...rest }: IdenticonProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <IdenticonStyle {...rest} ref={ref}>
-      <Jazzicon seed={jsNumberForAddress(address)} {...iconProps} />
+      <Jazzicon
+        seed={jsNumberForAddress(address)}
+        diameter={diameter}
+        paperStyles={paperStyles}
+        svgStyles={svgStyles}
+      />
     </IdenticonStyle>
   )
 }

--- a/packages/identicon/IdenticonBadge.tsx
+++ b/packages/identicon/IdenticonBadge.tsx
@@ -1,14 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { Address } from '@lidofinance/address'
 import { IdenticonBadgeProps } from './types'
 import { IdenticonBadgeStyle, AddressWrapperStyle } from './IdenticonStyles'
 import Identicon from './Identicon'
 
 function IdenticonBadge(
-  props: IdenticonBadgeProps,
-  ref?: ForwardedRef<HTMLDivElement>,
-) {
-  const {
+  {
     symbols = 3,
     color = 'background',
     diameter,
@@ -16,9 +13,9 @@ function IdenticonBadge(
     paperStyles,
     svgStyles,
     ...rest
-  } = props
-  const identiconProps = { address, diameter, paperStyles, svgStyles }
-
+  }: IdenticonBadgeProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <IdenticonBadgeStyle $color={color} {...rest} ref={ref}>
       {symbols > 0 ? (
@@ -28,7 +25,12 @@ function IdenticonBadge(
       ) : (
         ''
       )}
-      <Identicon {...identiconProps} />
+      <Identicon
+        address={address}
+        diameter={diameter}
+        paperStyles={paperStyles}
+        svgStyles={svgStyles}
+      />
     </IdenticonBadgeStyle>
   )
 }

--- a/packages/identicon/types.ts
+++ b/packages/identicon/types.ts
@@ -1,5 +1,5 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React from 'react'
+import { CSSProperties } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export type IdenticonProps = LidoComponentProps<
@@ -7,8 +7,8 @@ export type IdenticonProps = LidoComponentProps<
   {
     address: string
     diameter?: number
-    paperStyles?: React.CSSProperties
-    svgStyles?: React.CSSProperties
+    paperStyles?: CSSProperties
+    svgStyles?: CSSProperties
   }
 >
 

--- a/packages/input/Input.stories.tsx
+++ b/packages/input/Input.stories.tsx
@@ -237,8 +237,7 @@ AccentColor.args = {
   placeholder: 'Ethereum address',
 }
 
-const useModal = (props: ModalProps) => {
-  const { onClose, onBack } = props
+const useModal = ({ onClose, onBack }: ModalProps) => {
   const [state, setState] = useState(false)
   const handleOpen = useCallback(() => setState(true), [])
   const handleClose = useCallback(() => {

--- a/packages/input/Input.tsx
+++ b/packages/input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import {
   InputWrapperStyle,
   InputContentStyle,
@@ -11,8 +11,8 @@ import {
 import { InputLabelStyle } from './LabelStyles'
 import { InputProps } from './types'
 
-function Input(props: InputProps, ref?: ForwardedRef<HTMLInputElement>) {
-  const {
+function Input(
+  {
     label,
     error,
     warning,
@@ -26,14 +26,14 @@ function Input(props: InputProps, ref?: ForwardedRef<HTMLInputElement>) {
     style,
     variant = 'default',
     color = 'default',
+    id,
+    disabled = false,
     wrapperRef,
     children,
     ...rest
-  } = props
-
-  const { id, disabled = false } = props
-  const wrapperProps = { className, style }
-
+  }: InputProps,
+  ref?: ForwardedRef<HTMLInputElement>,
+) {
   const hasLabel = !!label && variant === 'default'
 
   const hasError = !!error
@@ -48,11 +48,12 @@ function Input(props: InputProps, ref?: ForwardedRef<HTMLInputElement>) {
 
   return (
     <InputWrapperStyle
+      className={className}
+      style={style}
       $disabled={disabled}
       $fullwidth={fullwidth}
       htmlFor={id}
       ref={wrapperRef}
-      {...wrapperProps}
     >
       <InputContentStyle
         $color={color}

--- a/packages/input/InputGroup.tsx
+++ b/packages/input/InputGroup.tsx
@@ -1,14 +1,12 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { InputMessageStyle } from './InputStyles'
 import { InputGroupStyle, InputGroupContentStyle } from './InputGroupStyles'
 import { InputGroupProps } from './types'
 
 function InputGroup(
-  props: InputGroupProps,
+  { fullwidth = false, error, success, children, ...rest }: InputGroupProps,
   ref?: ForwardedRef<HTMLSpanElement>,
 ) {
-  const { fullwidth = false, error, success, children, ...rest } = props
-
   const hasError = !!error
   const hasSuccess = !!success && !error
 

--- a/packages/input/OptionsSlider.stories.tsx
+++ b/packages/input/OptionsSlider.stories.tsx
@@ -1,6 +1,6 @@
 import { Story, Meta } from '@storybook/react'
 import { SliderInputProps } from './types'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import OptionsSlider from './OptionsSlider'
 
 export default {

--- a/packages/input/OptionsSlider.tsx
+++ b/packages/input/OptionsSlider.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import SliderInput from './SliderInput'
 import { OptionsSliderInputProps } from './types'
 

--- a/packages/input/SliderInput.stories.tsx
+++ b/packages/input/SliderInput.stories.tsx
@@ -1,6 +1,6 @@
 import { Story, Meta } from '@storybook/react'
 import { SliderInputProps } from './types'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import SliderInput from './SliderInput'
 
 export default {

--- a/packages/input/SliderInput.tsx
+++ b/packages/input/SliderInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { ReactElement } from 'react'
 import {
   Label,
   LabelButton,
@@ -22,7 +22,7 @@ function SliderInput({
   getLabel = (val) => String(val),
   borderNone,
   labels,
-}: SliderInputProps): React.ReactElement {
+}: SliderInputProps): ReactElement {
   const fillPercentage = ((value - min) / (max - min)) * 100
   const LabelComponent = onLabelClick ? LabelButton : Label
   const createClickHandler = (value: number) => () => onLabelClick?.(value)

--- a/packages/input/Textarea.tsx
+++ b/packages/input/Textarea.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import {
   InputWrapperStyle,
   InputContentStyle,
@@ -9,8 +9,8 @@ import {
 import { TextareaLabelStyle } from './LabelStyles'
 import { TextareaProps } from './types'
 
-function Textarea(props: TextareaProps, ref?: ForwardedRef<HTMLInputElement>) {
-  const {
+function Textarea(
+  {
     label,
     error,
     warning,
@@ -22,14 +22,14 @@ function Textarea(props: TextareaProps, ref?: ForwardedRef<HTMLInputElement>) {
     style,
     variant = 'default',
     color = 'default',
+    id,
+    disabled = false,
     wrapperRef,
     children,
     ...rest
-  } = props
-
-  const { id, disabled = false } = props
-  const wrapperProps = { className, style }
-
+  }: TextareaProps,
+  ref?: ForwardedRef<HTMLInputElement>,
+) {
   const hasLabel = !!label && variant === 'default'
 
   const hasError = !!error
@@ -41,11 +41,12 @@ function Textarea(props: TextareaProps, ref?: ForwardedRef<HTMLInputElement>) {
 
   return (
     <InputWrapperStyle
+      className={className}
+      style={style}
       $disabled={disabled}
       $fullwidth={fullwidth}
       htmlFor={id}
       ref={wrapperRef}
-      {...wrapperProps}
     >
       <InputContentStyle
         $color={color}

--- a/packages/input/types.ts
+++ b/packages/input/types.ts
@@ -1,5 +1,5 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React, { ChangeEventHandler } from 'react'
+import { ChangeEventHandler, ReactNode, RefObject } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export enum InputMessageVariant {
@@ -33,15 +33,15 @@ export enum InputColor {
 export type InputColors = keyof typeof InputColor
 
 type CommonProps = {
-  label?: React.ReactNode
-  error?: React.ReactNode | boolean
-  warning?: React.ReactNode | boolean
-  success?: React.ReactNode | boolean
+  label?: ReactNode
+  error?: ReactNode | boolean
+  warning?: ReactNode | boolean
+  success?: ReactNode | boolean
   variant?: InputVariants
   color?: InputColors
   active?: boolean
   fullwidth?: boolean
-  wrapperRef?: React.RefObject<HTMLLabelElement>
+  wrapperRef?: RefObject<HTMLLabelElement>
   as?: never
 }
 
@@ -49,8 +49,8 @@ export type InputProps = LidoComponentProps<
   'input',
   CommonProps & {
     type?: InputTypes
-    leftDecorator?: React.ReactNode
-    rightDecorator?: React.ReactNode
+    leftDecorator?: ReactNode
+    rightDecorator?: ReactNode
   }
 >
 
@@ -60,14 +60,14 @@ export type InputGroupProps = LidoComponentProps<
   'span',
   {
     fullwidth?: boolean
-    error?: React.ReactNode
-    success?: React.ReactNode
+    error?: ReactNode
+    success?: ReactNode
   }
 >
 
 interface ValueLabel {
   value: number
-  label: React.ReactNode
+  label: ReactNode
 }
 
 type SliderProps = {
@@ -75,10 +75,10 @@ type SliderProps = {
   onChange?: ChangeEventHandler<HTMLInputElement>
   min?: number
   max?: number
-  minLabel?: React.ReactNode
-  maxLabel?: React.ReactNode
+  minLabel?: ReactNode
+  maxLabel?: ReactNode
   step?: number
-  getLabel?: (value: number) => React.ReactNode
+  getLabel?: (value: number) => ReactNode
   borderNone?: boolean
   labels?: ValueLabel[]
   onLabelClick?: (value: number) => unknown
@@ -90,7 +90,7 @@ type SliderOptionValue = string | number
 
 interface SliderOption {
   value: SliderOptionValue
-  label: React.ReactNode
+  label: ReactNode
 }
 
 interface OptionsSliderProps {

--- a/packages/lido-logo/LidoLogo.tsx
+++ b/packages/lido-logo/LidoLogo.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { LidoLogoStyles } from './LidoLogoStyles'
 import { LidoLogoProps } from './types'
 

--- a/packages/link/Link.tsx
+++ b/packages/link/Link.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { LinkStyle } from './LinkStyles'
 import { LinkProps } from './types'
 

--- a/packages/loaders/InlineLoader.tsx
+++ b/packages/loaders/InlineLoader.tsx
@@ -1,12 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { InlineLoaderProps } from './types'
 import { InlineLoaderStyle } from './InlineLoaderStyles'
 
 function InlineLoader(
-  props: InlineLoaderProps,
+  { color, ...rest }: InlineLoaderProps,
   ref?: ForwardedRef<HTMLDivElement>,
 ) {
-  const { color, ...rest } = props
   const heightAdjuster = <>&nbsp;</>
 
   return (

--- a/packages/loaders/Loader.tsx
+++ b/packages/loaders/Loader.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { LoaderProps, LoaderSize } from './types'
 import {
   LoaderStyle,
@@ -6,9 +6,10 @@ import {
   LoaderCircleFgStyle,
 } from './LoaderStyles'
 
-function Loader(props: LoaderProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { size = 'medium', thickness = 3, color = 'primary', ...rest } = props
-
+function Loader(
+  { size = 'medium', thickness = 3, color = 'primary', ...rest }: LoaderProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   const pxSize = LoaderSize[size]
   const center = pxSize / 2
   const radius = pxSize / 2 - thickness / 2

--- a/packages/main-menu/MainMenu.tsx
+++ b/packages/main-menu/MainMenu.tsx
@@ -1,9 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { MainMenuProps } from './types'
 import { Nav } from './MainMenuStyles'
 
-function MainMenu(props: MainMenuProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { children, ...restProps } = props
+function MainMenu(
+  { children, ...restProps }: MainMenuProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <Nav ref={ref} {...restProps}>
       {children}

--- a/packages/main-menu/MainMenuItem.tsx
+++ b/packages/main-menu/MainMenuItem.tsx
@@ -1,12 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { MainMenuItemProps } from './types'
 import { NavLink } from './MainMenuItemStyles'
 
 function MainMenuItem(
-  props: MainMenuItemProps,
+  { icon, children, active, ...restProps }: MainMenuItemProps,
   ref?: ForwardedRef<HTMLDivElement>,
 ) {
-  const { icon, children, active, ...restProps } = props
   return (
     <NavLink ref={ref} active={Boolean(active)} {...restProps}>
       {icon}

--- a/packages/modal/Modal.stories.tsx
+++ b/packages/modal/Modal.stories.tsx
@@ -31,8 +31,7 @@ export default {
   },
 } as Meta
 
-const useModal = (props: ModalProps) => {
-  const { onClose, onBack } = props
+const useModal = ({ onClose, onBack }: ModalProps) => {
   const [state, setState] = useState(false)
   const handleOpen = useCallback(() => setState(true), [])
   const handleClose = useCallback(() => {

--- a/packages/modal/Modal.tsx
+++ b/packages/modal/Modal.tsx
@@ -1,5 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
-
+import { ForwardedRef, forwardRef } from 'react'
 import {
   ModalStyle,
   ModalBaseStyle,
@@ -15,8 +14,8 @@ import {
 import { ModalProps } from './types'
 import ModalOverlay from './ModalOverlay'
 
-function Modal(props: ModalProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const {
+function Modal(
+  {
     children,
     title,
     titleIcon,
@@ -24,10 +23,12 @@ function Modal(props: ModalProps, ref?: ForwardedRef<HTMLDivElement>) {
     center = false,
     extra,
     open,
+    onClose,
+    onBack,
     ...rest
-  } = props
-  const { onClose, onBack } = props
-
+  }: ModalProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   const withTitleIcon = !!titleIcon
   const withSubtitle = !!subtitle
   const withCloseButton = !!onClose

--- a/packages/modal/ModalButton.tsx
+++ b/packages/modal/ModalButton.tsx
@@ -1,5 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
-
+import { cloneElement, ForwardedRef, forwardRef } from 'react'
 import { ModalButtonStyle, ModalButtonContentStyle } from './ModalButtonStyles'
 import { ModalButtonIconProps } from './types'
 
@@ -27,14 +26,18 @@ const iconSize = {
 }
 
 function ModalButton(
-  props: ModalButtonIconProps,
+  {
+    size = 'md',
+    loading = false,
+    children,
+    icon,
+    ...rest
+  }: ModalButtonIconProps,
   ref?: ForwardedRef<HTMLButtonElement>,
 ) {
-  const { size = 'md', loading = false, children, icon } = props
-
   const AdaptiveIconProps =
     icon.props.width || icon.props.height ? icon.props : { ...iconSize[size] }
-  const AdaptiveIcon = React.cloneElement(icon, AdaptiveIconProps)
+  const AdaptiveIcon = cloneElement(icon, AdaptiveIconProps)
 
   return (
     <ModalButtonStyle
@@ -42,7 +45,8 @@ function ModalButton(
       size={size}
       loading={loading}
       ref={ref}
-      {...props}
+      icon={icon}
+      {...rest}
     >
       <ModalButtonContentStyle>
         {children} {AdaptiveIcon}

--- a/packages/modal/ModalExtra.tsx
+++ b/packages/modal/ModalExtra.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 
 import { ModalExtraStyle } from './ModalExtraStyles'
 import { ModalExtraProps } from './types'

--- a/packages/modal/ModalOverlay.tsx
+++ b/packages/modal/ModalOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import ReactDOM from 'react-dom'
 import { useMergeRefs, useEscape, useLockScroll } from '@lidofinance/hooks'
 import { withTransition } from '@lidofinance/transition'
@@ -13,10 +13,15 @@ import { useModalFocus } from './useModalFocus'
 import { useModalClose } from './useModalClose'
 
 function ModalOverlay(
-  props: ModalOverlayInnerProps,
+  {
+    onClose,
+    onBack,
+    duration,
+    transitionStatus,
+    ...rest
+  }: ModalOverlayInnerProps,
   externalRef?: ForwardedRef<HTMLDivElement>,
 ) {
-  const { onClose, onBack, duration, transitionStatus, ...rest } = props
   const closable = !!onClose
 
   useEscape(onClose)

--- a/packages/modal/ModalStyles.tsx
+++ b/packages/modal/ModalStyles.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled, { css } from 'styled-components'
 import { Close, ArrowBack } from '@lidofinance/icons'
 import { ButtonIcon } from '@lidofinance/button'

--- a/packages/modal/types.tsx
+++ b/packages/modal/types.tsx
@@ -4,7 +4,7 @@ import {
   TransitionInnerProps,
 } from '@lidofinance/transition'
 import { ButtonProps } from '@lidofinance/button'
-import React from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 export type ModalOverlayOwnProps = LidoComponentProps<
   'div',
@@ -18,10 +18,10 @@ export type ModalOverlayProps = ModalOverlayOwnProps & TransitionWrapperProps
 export type ModalOverlayInnerProps = ModalOverlayOwnProps & TransitionInnerProps
 
 export type ModalProps = {
-  title?: React.ReactNode
-  titleIcon?: React.ReactNode
-  subtitle?: React.ReactNode
-  extra?: React.ReactNode
+  title?: ReactNode
+  titleIcon?: ReactNode
+  subtitle?: ReactNode
+  extra?: ReactNode
   center?: boolean
   open?: boolean
 } & Omit<ModalOverlayProps, 'title' | 'in'>
@@ -29,5 +29,5 @@ export type ModalProps = {
 export type ModalExtraProps = LidoComponentProps<'div'>
 
 export type ModalButtonIconProps = {
-  icon: React.ReactElement
+  icon: ReactElement
 } & ButtonProps

--- a/packages/modal/useModalClose.ts
+++ b/packages/modal/useModalClose.ts
@@ -1,15 +1,15 @@
-import React, { useCallback, useRef } from 'react'
+import { MouseEvent, RefObject, useCallback, useRef } from 'react'
 
 export const useModalClose = <T extends HTMLDivElement>(
   callback?: () => void,
 ): {
-  ref: React.RefObject<T>
-  handleClick: (event: React.MouseEvent<T, MouseEvent>) => void
+  ref: RefObject<T>
+  handleClick: (event: MouseEvent<T>) => void
 } => {
   const ref = useRef<T>(null)
 
   const handleClick = useCallback(
-    (event: React.MouseEvent<T, MouseEvent>) => {
+    (event: MouseEvent<T>) => {
       const contentElement = ref.current
 
       if (!contentElement) return

--- a/packages/modal/useModalFocus.ts
+++ b/packages/modal/useModalFocus.ts
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import { RefObject, useCallback, useEffect, useRef } from 'react'
 import { useInterceptFocus } from '@lidofinance/hooks'
 import { FOCUSABLE_ELEMENTS } from './constants'
 
-export const useModalFocus = (): React.RefObject<HTMLDivElement> => {
+export const useModalFocus = (): RefObject<HTMLDivElement> => {
   const modalRef = useRef<HTMLDivElement>(null)
 
   const getFocusableNodes = useCallback(() => {

--- a/packages/pagination/Pagination.stories.tsx
+++ b/packages/pagination/Pagination.stories.tsx
@@ -1,6 +1,4 @@
-import React from 'react'
 import { Story, Meta } from '@storybook/react'
-
 import Pagination from './Pagination'
 import { PaginationProps } from './types'
 

--- a/packages/pagination/Pagination.tsx
+++ b/packages/pagination/Pagination.tsx
@@ -1,9 +1,7 @@
-import React, { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, FC, MouseEvent } from 'react'
 import styled from 'styled-components'
-
 import { ArrowLeft, ArrowRight } from '@lidofinance/icons'
 import { Box } from '@lidofinance/box'
-
 import {
   PaginationProps,
   PaginationItemProps,
@@ -27,9 +25,12 @@ const PaginationBlock = styled(Box)`
   gap: 8px;
 `
 
-const Pagination: React.FC<PaginationProps> = (props) => {
-  const { onItemClick, pagesCount, activePage = 1, siblingCount } = props
-
+const Pagination: FC<PaginationProps> = ({
+  onItemClick,
+  pagesCount,
+  activePage = 1,
+  siblingCount,
+}) => {
   const [currentPage, setCurrPage] = useState(
     getActiveItem(pagesCount, activePage),
   )
@@ -47,7 +48,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     return null
   }
 
-  const onPageItemClick = (page: number, e: React.MouseEvent) => {
+  const onPageItemClick = (page: number, e: MouseEvent) => {
     onItemClick(page, e)
     setCurrPage(page)
   }

--- a/packages/pagination/PaginationItem.stories.tsx
+++ b/packages/pagination/PaginationItem.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
 import { PaginationItemVariant, PaginationItemProps } from './types'

--- a/packages/pagination/PaginationItem.tsx
+++ b/packages/pagination/PaginationItem.tsx
@@ -1,9 +1,12 @@
-import React from 'react'
+import { FC } from 'react'
 import { PaginationItemStyle } from './PaginationItemStyles'
 import { PaginationItemProps, PaginationItemVariant } from './types'
 
-const PaginationItem: React.FC<PaginationItemProps> = (props) => {
-  const { icon, variant = PaginationItemVariant.default, ...rest } = props
+const PaginationItem: FC<PaginationItemProps> = ({
+  icon,
+  variant = PaginationItemVariant.default,
+  ...rest
+}) => {
   return (
     <PaginationItemStyle $variant={variant} {...rest}>
       {icon}

--- a/packages/pagination/types.ts
+++ b/packages/pagination/types.ts
@@ -1,9 +1,9 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React from 'react'
+import { MouseEvent, ReactNode } from 'react'
 
 export type SiblingsCount = 0 | 1
 
-export type onItemClick = (index: number, e?: React.MouseEvent) => void
+export type onItemClick = (index: number, e?: MouseEvent) => void
 
 export type PaginationProps = LidoComponentProps<
   'div',
@@ -24,6 +24,6 @@ export type PaginationItemProps = LidoComponentProps<
   'button',
   {
     variant?: PaginationItemVariant
-    icon: React.ReactNode
+    icon: ReactNode
   }
 >

--- a/packages/popover/Popover.stories.tsx
+++ b/packages/popover/Popover.stories.tsx
@@ -1,7 +1,6 @@
 import { Story, Meta } from '@storybook/react'
 import { Button } from '@lidofinance/button'
 import { PopoverProps, PopoverPlacement, PopoverOffset } from './types'
-
 import Popover from './Popover'
 import { useCallback, useRef, useState } from 'react'
 import { DEFAULT_PLACEMENT } from './constants'
@@ -39,9 +38,7 @@ export default {
   },
 } as Meta
 
-export const Basic: Story<PopoverProps> = (props) => {
-  const { onClose } = props
-
+export const Basic: Story<PopoverProps> = ({ onClose, ...rest }) => {
   const [state, setState] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
 
@@ -60,9 +57,9 @@ export const Basic: Story<PopoverProps> = (props) => {
         Open Popover
       </Button>
       <Popover
-        {...props}
         open={state}
         onClose={handleClose}
+        {...rest}
         anchorRef={anchorRef}
       >
         Popover

--- a/packages/popover/Popover.tsx
+++ b/packages/popover/Popover.tsx
@@ -1,17 +1,17 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { DEFAULT_PLACEMENT } from './constants'
-
 import { PopoverStyle } from './PopoverStyles'
 import { PopoverProps } from './types'
 
-function Popover(props: PopoverProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const {
+function Popover(
+  {
     placement = DEFAULT_PLACEMENT,
     open = false,
     offset = 'xs',
     ...rest
-  } = props
-
+  }: PopoverProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <PopoverStyle
       $offset={offset}

--- a/packages/popover/PopoverRoot.tsx
+++ b/packages/popover/PopoverRoot.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import ReactDOM from 'react-dom'
 import { modalRoot } from '@lidofinance/utils'
 import { useMergeRefs, useOutsideClick, useEscape } from '@lidofinance/hooks'
@@ -9,20 +9,19 @@ import { PopoverRootInnerProps } from './types'
 import { DEFAULT_PLACEMENT } from './constants'
 
 function PopoverRoot(
-  props: PopoverRootInnerProps,
-  externalRef?: ForwardedRef<HTMLDivElement>,
-) {
-  const {
+  {
     anchorRef,
     wrapperRef: externalWrapperRef,
     placement = DEFAULT_PLACEMENT,
     backdrop = true,
     transitionStatus,
     duration,
+    style: propsStyle,
+    onClose,
     ...rest
-  } = props
-
-  const { onClose } = props
+  }: PopoverRootInnerProps,
+  externalRef?: ForwardedRef<HTMLDivElement>,
+) {
   useEscape(onClose)
   const { ref: outsidePopoverRef } = useOutsideClick(onClose)
 
@@ -30,7 +29,7 @@ function PopoverRoot(
     popoverRef: positionPopoverRef,
     wrapperRef: positionWrapperRef,
     style,
-  } = usePopoverPosition(props)
+  } = usePopoverPosition({ placement, anchorRef, style: propsStyle })
 
   const popoverRef = useMergeRefs([
     positionPopoverRef,

--- a/packages/popover/PopoverStyles.ts
+++ b/packages/popover/PopoverStyles.ts
@@ -9,8 +9,7 @@ type InjectedProps = {
   theme: Theme
 }
 
-const getOffset = (props: InjectedProps): string => {
-  const { $offset, placement, theme } = props
+const getOffset = ({ $offset, placement, theme }: InjectedProps): string => {
   const offset = theme.spaceMap[$offset]
 
   if (placement.startsWith('top')) return `margin-top: ${-offset}px`

--- a/packages/popover/types.ts
+++ b/packages/popover/types.ts
@@ -3,7 +3,7 @@ import {
   TransitionWrapperProps,
   TransitionInnerProps,
 } from '@lidofinance/transition'
-import React from 'react'
+import { RefObject } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export enum PopoverOffset {
@@ -37,8 +37,8 @@ export type PopoverPlacements = keyof typeof PopoverPlacement
 export type PopoverRootOwnProps = LidoComponentProps<
   'div',
   {
-    wrapperRef?: React.RefObject<HTMLDivElement>
-    anchorRef: React.RefObject<HTMLElement | null>
+    wrapperRef?: RefObject<HTMLDivElement>
+    anchorRef: RefObject<HTMLElement | null>
     placement?: PopoverPlacements
     backdrop?: boolean
     onClose?: () => void

--- a/packages/popover/usePopoverPosition.ts
+++ b/packages/popover/usePopoverPosition.ts
@@ -1,4 +1,10 @@
-import React, { useRef, useLayoutEffect, useState, CSSProperties } from 'react'
+import {
+  useRef,
+  useLayoutEffect,
+  useState,
+  CSSProperties,
+  RefObject,
+} from 'react'
 import { useWindowSize } from '@lidofinance/hooks'
 import { PopoverRootProps } from './types'
 import { INITIAL_STYLE, DEFAULT_PLACEMENT } from './constants'
@@ -7,15 +13,15 @@ import { calculatePosition } from './calculatePosition'
 export const usePopoverPosition = <
   P extends HTMLDivElement,
   W extends HTMLDivElement,
->(
-  props: PopoverRootProps,
-): {
-  popoverRef: React.RefObject<P>
-  wrapperRef: React.RefObject<W>
+>({
+  placement = DEFAULT_PLACEMENT,
+  anchorRef,
+  style: propsStyle,
+}: Pick<PopoverRootProps, 'placement' | 'anchorRef' | 'style'>): {
+  popoverRef: RefObject<P>
+  wrapperRef: RefObject<W>
   style: CSSProperties
 } => {
-  const { placement = DEFAULT_PLACEMENT, anchorRef } = props
-
   const popoverRef = useRef<P>(null)
   const wrapperRef = useRef<W>(null)
 
@@ -39,7 +45,7 @@ export const usePopoverPosition = <
   }, [anchorRef, placement, windowWidth, windowHeight])
 
   const style = {
-    ...props.style,
+    ...propsStyle,
     ...popoverStyle,
   }
 

--- a/packages/popup-menu/PopupMenu.stories.tsx
+++ b/packages/popup-menu/PopupMenu.stories.tsx
@@ -23,9 +23,7 @@ export default {
   },
 } as Meta
 
-const usePopup = (props: PopupMenuProps) => {
-  const { onClose } = props
-
+const usePopup = ({ onClose }: PopupMenuProps) => {
   const [state, setState] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
 

--- a/packages/popup-menu/PopupMenu.tsx
+++ b/packages/popup-menu/PopupMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { useMergeRefs } from '@lidofinance/hooks'
 import { PopupMenuProvider } from './PopupMenuProvider'
 import { PopupMenuStyle } from './PopupMenuStyles'
@@ -6,18 +6,16 @@ import { PopupMenuProps } from './types'
 import { usePopupFocus } from './usePopupFocus'
 
 function PopupMenu(
-  props: PopupMenuProps,
+  { variant, children, onKeyDown, onMouseMove, ...rest }: PopupMenuProps,
   externalRef?: ForwardedRef<HTMLDivElement>,
 ) {
-  const { variant, children, onKeyDown, onMouseMove, ...rest } = props
-
   const {
     ref: controlRef,
     handleMouseMove,
     handleKeyDown,
     handleEnter,
     handleExit,
-  } = usePopupFocus(props)
+  } = usePopupFocus({ onMouseMove, onKeyDown })
   const popupRef = useMergeRefs([controlRef, externalRef])
 
   return (

--- a/packages/popup-menu/PopupMenuItem.tsx
+++ b/packages/popup-menu/PopupMenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import {
   PopupMenuItemStyle,
   PopupMenuItemContentStyle,
@@ -9,16 +9,15 @@ import { usePopupMenuContext } from './PopupMenuProvider'
 import { PopupMenuItemProps } from './types'
 
 function PopupMenuItem(
-  props: PopupMenuItemProps,
-  ref?: ForwardedRef<HTMLButtonElement>,
-) {
-  const {
+  {
     active = false,
     leftDecorator,
     rightDecorator,
     children,
     ...rest
-  } = props
+  }: PopupMenuItemProps,
+  ref?: ForwardedRef<HTMLButtonElement>,
+) {
   const { variant = 'default' } = usePopupMenuContext()
 
   const hasLeftDecorator = !!leftDecorator

--- a/packages/popup-menu/PopupMenuProvider.tsx
+++ b/packages/popup-menu/PopupMenuProvider.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, createContext, useContext, FC } from 'react'
+import { PropsWithChildren, createContext, useContext, FC } from 'react'
 import { PopupMenuVariants } from './types'
 
 export interface PopupMenuContext {
@@ -11,10 +11,9 @@ export const usePopupMenuContext = (): PopupMenuContext => {
   return useContext(Context)
 }
 
-export const PopupMenuProvider: FC<PropsWithChildren<PopupMenuContext>> = (
-  props,
-) => {
-  const { variant, ...rest } = props
-
+export const PopupMenuProvider: FC<PropsWithChildren<PopupMenuContext>> = ({
+  variant,
+  ...rest
+}) => {
   return <Context.Provider value={{ variant }} {...rest} />
 }

--- a/packages/popup-menu/types.ts
+++ b/packages/popup-menu/types.ts
@@ -1,6 +1,6 @@
 import { LidoComponentProps } from '@lidofinance/utils'
 import { PopoverProps } from '@lidofinance/popover'
-import React from 'react'
+import { ReactNode } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export enum PopupMenuVariant {
@@ -16,8 +16,8 @@ export type PopupMenuProps = {
 export type PopupMenuItemProps = LidoComponentProps<
   'button',
   {
-    leftDecorator?: React.ReactNode
-    rightDecorator?: React.ReactNode
+    leftDecorator?: ReactNode
+    rightDecorator?: ReactNode
     active?: boolean
   }
 >

--- a/packages/popup-menu/usePopupFocus.ts
+++ b/packages/popup-menu/usePopupFocus.ts
@@ -1,18 +1,25 @@
-import React, { useCallback, useRef } from 'react'
+import {
+  KeyboardEvent,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  RefObject,
+  useCallback,
+  useRef,
+} from 'react'
 import { useInterceptFocus } from '@lidofinance/hooks'
 import { FOCUSABLE_ELEMENTS } from './constants'
 import { PopupMenuProps } from './types'
 
-export const usePopupFocus = <T extends HTMLDivElement>(
-  props: PopupMenuProps,
-): {
-  ref: React.RefObject<T>
-  handleMouseMove: React.MouseEventHandler<T>
-  handleKeyDown: React.KeyboardEventHandler<T>
+export const usePopupFocus = <T extends HTMLDivElement>({
+  onMouseMove,
+  onKeyDown,
+}: Pick<PopupMenuProps, 'onMouseMove' | 'onKeyDown'>): {
+  ref: RefObject<T>
+  handleMouseMove: MouseEventHandler<T>
+  handleKeyDown: KeyboardEventHandler<T>
   handleEnter: () => void
   handleExit: () => void
 } => {
-  const { onMouseMove, onKeyDown } = props
   const ref = useRef<T>(null)
 
   const getFocusableNodes = useCallback(() => {
@@ -26,7 +33,7 @@ export const usePopupFocus = <T extends HTMLDivElement>(
   }, [])
 
   const handleFocusTo = useCallback(
-    (event: React.KeyboardEvent<T>, offset = 1) => {
+    (event: KeyboardEvent<T>, offset = 1) => {
       const focusableNodes = getFocusableNodes()
 
       if (focusableNodes.length === 0) return
@@ -54,7 +61,7 @@ export const usePopupFocus = <T extends HTMLDivElement>(
     [getFocusableNodes],
   )
 
-  const handleMouseMove: React.MouseEventHandler<T> = useCallback(
+  const handleMouseMove: MouseEventHandler<T> = useCallback(
     (event) => {
       onMouseMove?.(event)
 
@@ -76,7 +83,7 @@ export const usePopupFocus = <T extends HTMLDivElement>(
     [getFocusableNodes, onMouseMove],
   )
 
-  const handleKeyDown: React.KeyboardEventHandler<T> = useCallback(
+  const handleKeyDown: KeyboardEventHandler<T> = useCallback(
     (event) => {
       onKeyDown?.(event)
       const code = event.code ?? event.key

--- a/packages/section/Section.tsx
+++ b/packages/section/Section.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { SectionProps } from './types'
 import {
   SectionStyle,
@@ -7,9 +7,10 @@ import {
   SectionHeaderDecoratorStyle,
 } from './SectionStyles'
 
-function Section(props: SectionProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { title, headerDecorator, children, ...rest } = props
-
+function Section(
+  { title, headerDecorator, children, ...rest }: SectionProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <SectionStyle {...rest} ref={ref}>
       {title && (

--- a/packages/section/types.ts
+++ b/packages/section/types.ts
@@ -1,10 +1,10 @@
-import React from 'react'
 import { LidoComponentProps } from '@lidofinance/utils'
+import { ReactNode } from 'react'
 
 export type SectionProps = LidoComponentProps<
   'div',
   {
-    title?: React.ReactNode
-    headerDecorator?: React.ReactNode
+    title?: ReactNode
+    headerDecorator?: ReactNode
   }
 >

--- a/packages/select/Option.tsx
+++ b/packages/select/Option.tsx
@@ -1,12 +1,13 @@
-import React, { ForwardedRef, forwardRef, useCallback } from 'react'
+import { ForwardedRef, forwardRef, MouseEvent, useCallback } from 'react'
 import { PopupMenuItem } from '@lidofinance/popup-menu'
 import { OptionProps } from './types'
 
-function Option(props: OptionProps, ref?: ForwardedRef<HTMLButtonElement>) {
-  const { value, onClick, onChange, ...rest } = props
-
+function Option(
+  { value, onClick, onChange, ...rest }: OptionProps,
+  ref?: ForwardedRef<HTMLButtonElement>,
+) {
   const handleClick = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
+    (event: MouseEvent<HTMLButtonElement>) => {
       onChange?.(value)
       onClick?.(event)
     },

--- a/packages/select/Select.stories.tsx
+++ b/packages/select/Select.stories.tsx
@@ -99,15 +99,21 @@ OnlyIcon.argTypes = {
   },
 }
 
-export const WithInput: Story<SelectProps> = (props) => {
-  const { fullwidth, disabled, color } = props
+export const WithInput: Story<SelectProps> = ({
+  fullwidth,
+  disabled,
+  color,
+  ...rest
+}) => {
   const [value, setValue] = useState<keyof typeof iconsMap>('eth')
   const ref = useRef<HTMLSpanElement>(null)
 
   return (
     <InputGroup fullwidth={fullwidth} ref={ref}>
       <SelectIcon
-        {...props}
+        {...rest}
+        disabled={disabled}
+        color={color}
         anchorRef={ref}
         icon={iconsMap[value]}
         value={value}

--- a/packages/select/Select.tsx
+++ b/packages/select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef, useRef } from 'react'
+import { ForwardedRef, forwardRef, useRef } from 'react'
 import { SelectWrapperStyle } from './SelectStyles'
 import { SelectArrow } from './SelectArrow'
 import { useMergeRefs } from '@lidofinance/hooks'
@@ -7,27 +7,37 @@ import { SelectProps } from './types'
 import { useSelect } from './useSelect'
 import { useSelectWidth } from './useSelectWidth'
 
-function Select(props: SelectProps, ref?: ForwardedRef<HTMLInputElement>) {
-  const {
+function Select(
+  {
     wrapperRef: externalWrapperRef,
     anchorRef: externalAnchorRef,
     arrow = 'default',
     variant,
     value,
     defaultValue,
+    disabled,
     children,
+    onClick,
+    onKeyDown,
     onChange,
     ...rest
-  } = props
-
-  const { disabled } = props
-
+  }: SelectProps,
+  ref?: ForwardedRef<HTMLInputElement>,
+) {
   const localAnchorRef = useRef<HTMLLabelElement>(null)
   const wrapperRef = useMergeRefs([localAnchorRef, externalWrapperRef])
   const anchorRef = externalAnchorRef || localAnchorRef
 
   const { opened, options, title, handleClick, handleClose, handleKeyDown } =
-    useSelect(props)
+    useSelect({
+      value,
+      defaultValue,
+      disabled,
+      onClick,
+      onChange,
+      onKeyDown,
+      children,
+    })
   const width = useSelectWidth(opened, anchorRef)
 
   return (

--- a/packages/select/SelectArrow.tsx
+++ b/packages/select/SelectArrow.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { SelectArrowBigStyle, SelectArrowSmallStyle } from './SelectArrowStyles'
 import { SelectArrows } from './types'
 
@@ -9,9 +9,11 @@ type SelectArrowProps = {
   children?: never
 }
 
-export const SelectArrow: FC<SelectArrowProps> = (props) => {
-  const { arrow, disabled = false, opened } = props
-
+export const SelectArrow: FC<SelectArrowProps> = ({
+  arrow,
+  disabled = false,
+  opened,
+}) => {
   const commonProps = {
     $opened: opened,
     $disabled: disabled,

--- a/packages/select/SelectIcon.tsx
+++ b/packages/select/SelectIcon.tsx
@@ -1,13 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { SelectIconProps } from './types'
 import { SelectIconDecoratorStyle, SelectIconStyle } from './SelectIconStyles'
 
 function SelectIcon(
-  props: SelectIconProps,
+  { icon, ...rest }: SelectIconProps,
   ref?: ForwardedRef<HTMLInputElement>,
 ) {
-  const { icon, ...rest } = props
-
   return (
     <SelectIconStyle
       {...rest}

--- a/packages/select/types.ts
+++ b/packages/select/types.ts
@@ -1,6 +1,6 @@
 import { InputProps } from '@lidofinance/input'
 import { PopupMenuItemProps } from '@lidofinance/popup-menu'
-import React from 'react'
+import { ReactNode, RefObject } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export type OptionValue = string | number
@@ -16,7 +16,7 @@ export type SelectProps = Omit<
   InputProps,
   'type' | 'readonly' | 'onChange' | 'value' | 'defaultValue'
 > & {
-  anchorRef?: React.RefObject<HTMLElement | null>
+  anchorRef?: RefObject<HTMLElement | null>
   arrow?: SelectArrows
   value?: OptionValue
   defaultValue?: OptionValue
@@ -27,7 +27,7 @@ export type SelectIconProps = Omit<
   SelectProps,
   'leftDecorator' | 'fullwidth' | 'arrow'
 > & {
-  icon: React.ReactNode
+  icon: ReactNode
 }
 
 export type OptionProps = Omit<PopupMenuItemProps, 'value' | 'children'> & {

--- a/packages/select/useSelect.ts
+++ b/packages/select/useSelect.ts
@@ -1,35 +1,52 @@
-import React, {
+import {
   useCallback,
   useMemo,
   useState,
   Children,
   cloneElement,
   useEffect,
+  MouseEvent,
+  KeyboardEvent,
+  ReactNode,
 } from 'react'
 import { isElement } from 'react-is'
 import { SelectProps, SelectHandleChange, OptionValue } from './types'
 
-type SelectHandleClick = (
-  event: React.MouseEvent<HTMLInputElement, MouseEvent>,
-) => void
+type SelectHandleClick = (event: MouseEvent<HTMLInputElement>) => void
 
-type SelectHandleKeyDown = (
-  event: React.KeyboardEvent<HTMLInputElement>,
-) => void
+type SelectHandleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => void
 
 type SelectHandleClose = () => void
 
-type UseSelect = (props: SelectProps) => {
+type UseSelect = (
+  props: Pick<
+    SelectProps,
+    | 'disabled'
+    | 'onClick'
+    | 'onChange'
+    | 'onKeyDown'
+    | 'children'
+    | 'value'
+    | 'defaultValue'
+  >,
+) => {
   handleClick: SelectHandleClick
   handleClose: SelectHandleClose
   handleKeyDown: SelectHandleKeyDown
   opened: boolean
   title: string
-  options: React.ReactNode
+  options: ReactNode
 }
 
-export const useSelect: UseSelect = (props) => {
-  const { disabled, onClick, onChange, onKeyDown, children } = props
+export const useSelect: UseSelect = ({
+  value,
+  defaultValue,
+  disabled,
+  onClick,
+  onChange,
+  onKeyDown,
+  children,
+}) => {
   const [opened, setOpened] = useState(false)
 
   const handleOpen = useCallback(() => {
@@ -69,7 +86,7 @@ export const useSelect: UseSelect = (props) => {
     [handleOpen, onKeyDown],
   )
 
-  const outerValue = props.value ?? props.defaultValue ?? null
+  const outerValue = value ?? defaultValue ?? null
   const [localValue, setLocalValue] = useState<OptionValue | null>(outerValue)
 
   useEffect(() => {
@@ -79,7 +96,7 @@ export const useSelect: UseSelect = (props) => {
   const { values, options } = useMemo(() => {
     const values = new Map<OptionValue, string>()
 
-    const options: React.ReactNode = Children.map(children, (child) => {
+    const options: ReactNode = Children.map(children, (child) => {
       if (!isElement(child)) return child
 
       const value = child.props.value

--- a/packages/select/useSelectWidth.ts
+++ b/packages/select/useSelectWidth.ts
@@ -1,8 +1,8 @@
-import React, { useCallback, useState, useEffect } from 'react'
+import { useCallback, useState, useEffect, RefObject } from 'react'
 
 export const useSelectWidth = <T extends HTMLElement>(
   opened: boolean,
-  anchorRef: React.RefObject<T | null>,
+  anchorRef: RefObject<T | null>,
 ): number | undefined => {
   const [width, setWidth] = useState<number>()
 

--- a/packages/service-page/ServicePage.tsx
+++ b/packages/service-page/ServicePage.tsx
@@ -1,14 +1,13 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { ServicePageStyle, ServicePageInsideStyle } from './ServicePageStyles'
 import { H1 } from '@lidofinance/heading'
 import { Text } from '@lidofinance/text'
 import { ServicePageProps } from './types'
 
 function ServicePage(
-  props: ServicePageProps,
+  { title, children, ...rest }: ServicePageProps,
   ref?: ForwardedRef<HTMLDivElement>,
 ) {
-  const { title, children, ...rest } = props
   return (
     <ServicePageStyle {...rest} ref={ref}>
       <ServicePageInsideStyle>

--- a/packages/service-page/types.ts
+++ b/packages/service-page/types.ts
@@ -1,9 +1,9 @@
 import { LidoComponentProps } from '@lidofinance/utils'
-import React from 'react'
+import { ReactNode } from 'react'
 
 export type ServicePageProps = LidoComponentProps<
   'div',
   {
-    title: React.ReactNode
+    title: ReactNode
   }
 >

--- a/packages/stack/HStack.tsx
+++ b/packages/stack/HStack.tsx
@@ -1,9 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { HStackProps } from './types'
 import Stack from './Stack'
 
-function HStack(props: HStackProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { reverse = false, ...rest } = props
+function HStack(
+  { reverse = false, ...rest }: HStackProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   const direction = reverse ? 'row-reverse' : 'row'
 
   return <Stack direction={direction} ref={ref} {...rest} />

--- a/packages/stack/Stack.tsx
+++ b/packages/stack/Stack.tsx
@@ -1,10 +1,10 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { StackProvider } from './StackProvider'
 import { StackStyle } from './StackStyles'
 import { StackProps } from './types'
 
-function Stack(props: StackProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const {
+function Stack(
+  {
     align = 'flex-start',
     justify = 'flex-start',
     direction = 'row',
@@ -12,8 +12,9 @@ function Stack(props: StackProps, ref?: ForwardedRef<HTMLDivElement>) {
     spacing,
     children,
     ...rest
-  } = props
-
+  }: StackProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   return (
     <StackStyle
       $align={align}

--- a/packages/stack/StackItem.tsx
+++ b/packages/stack/StackItem.tsx
@@ -1,10 +1,12 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { StackItemStyle } from './StackItemStyles'
 import { useStackContext } from './StackProvider'
 import { StackItemProps } from './types'
 
-function StackItem(props: StackItemProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { grow = 0, shrink = 0, basis = 'auto', ...rest } = props
+function StackItem(
+  { grow = 0, shrink = 0, basis = 'auto', ...rest }: StackItemProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   const { spacing } = useStackContext()
 
   return (

--- a/packages/stack/StackProvider.tsx
+++ b/packages/stack/StackProvider.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, createContext, useContext, FC } from 'react'
+import { PropsWithChildren, createContext, useContext, FC } from 'react'
 import { StackSpacings } from './types'
 
 export interface StackContext {
@@ -11,8 +11,9 @@ export const useStackContext = (): StackContext => {
   return useContext(Context)
 }
 
-export const StackProvider: FC<PropsWithChildren<StackContext>> = (props) => {
-  const { spacing, ...rest } = props
-
+export const StackProvider: FC<PropsWithChildren<StackContext>> = ({
+  spacing,
+  ...rest
+}) => {
   return <Context.Provider value={{ spacing }} {...rest} />
 }

--- a/packages/stack/VStack.tsx
+++ b/packages/stack/VStack.tsx
@@ -1,9 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { VStackProps } from './types'
 import Stack from './Stack'
 
-function VStack(props: VStackProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { reverse = false, ...rest } = props
+function VStack(
+  { reverse = false, ...rest }: VStackProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   const direction = reverse ? 'column-reverse' : 'column'
 
   return <Stack direction={direction} ref={ref} {...rest} />

--- a/packages/styled-system/withStyledSystem.test.tsx
+++ b/packages/styled-system/withStyledSystem.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import withStyledSystem from './withStyledSystem'
 import { ThemeProvider, themeDefault } from '@lidofinance/theme'
@@ -9,7 +9,7 @@ import 'jest-styled-components'
 const StyledComponent = withStyledSystem(styled.div``)
 const RegularComponent = withStyledSystem(
   forwardRef(function Regular(
-    props: React.HTMLAttributes<HTMLDivElement>,
+    props: HTMLAttributes<HTMLDivElement>,
     ref?: ForwardedRef<HTMLDivElement>,
   ) {
     return <div {...props} ref={ref} />

--- a/packages/styled-system/withStyledSystem.tsx
+++ b/packages/styled-system/withStyledSystem.tsx
@@ -24,9 +24,8 @@ import {
   position,
   shadow,
 } from 'styled-system'
-
 import { StyledSystemProps } from './types'
-import React from 'react'
+import { ComponentType } from 'react'
 
 type MergePropsWithSS<T extends object> = Omit<T, keyof StyledSystemProps> &
   StyledSystemProps
@@ -46,7 +45,7 @@ function withStyledSystem<
 >
 
 function withStyledSystem<
-  C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+  C extends keyof JSX.IntrinsicElements | ComponentType<any>,
   T extends object = DefaultTheme,
   O extends object = {},
   A extends keyof any = never,

--- a/packages/table/Table.stories.tsx
+++ b/packages/table/Table.stories.tsx
@@ -48,13 +48,11 @@ export const Base: Story<
 > = (props, options) => {
   const [sortDir, setSortDir] = useState<ThSortDirs>('ASC')
 
-  // @ts-expect-error fix later
   const isShowTrHighlights = options.args.showHighlight
 
   return (
     <div style={{ height: 300, overflowY: 'scroll' }}>
       <Table style={{ width: 600 }}>
-        {/* @ts-expect-error fix later */}
         <Thead sticky={options.args.stickyHeader}>
           <Tr>
             <Th

--- a/packages/table/Table.tsx
+++ b/packages/table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { TableProps } from './types'
 
 import { TableStyle } from './styles'

--- a/packages/table/Tbody.tsx
+++ b/packages/table/Tbody.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { TbodyProps } from './types'
 
 import { TbodyStyle } from './styles'

--- a/packages/table/Td.tsx
+++ b/packages/table/Td.tsx
@@ -1,18 +1,18 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { TdProps } from './types'
-
 import { TdStyle, ThTdContentStyle } from './styles'
 
-function Td(props: TdProps, ref?: ForwardedRef<HTMLTableDataCellElement>) {
-  const {
+function Td(
+  {
     align = 'left',
     textColor = 'default',
     variant,
     children,
     numeric = false,
     ...rest
-  } = props
-
+  }: TdProps,
+  ref?: ForwardedRef<HTMLTableDataCellElement>,
+) {
   return (
     <TdStyle
       $align={align}

--- a/packages/table/Tfoot.tsx
+++ b/packages/table/Tfoot.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { TfootProps } from './types'
 
 import { TfootStyle } from './styles'

--- a/packages/table/Th.tsx
+++ b/packages/table/Th.tsx
@@ -1,6 +1,5 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { ThProps } from './types'
-
 import {
   ThStyle,
   ThTdContentStyle,
@@ -8,9 +7,10 @@ import {
   ArrowTopStyle,
 } from './styles'
 
-function Th(props: ThProps, ref?: ForwardedRef<HTMLTableHeaderCellElement>) {
-  const { align = 'left', children, sortDir, variant, ...rest } = props
-
+function Th(
+  { align = 'left', children, sortDir, variant, ...rest }: ThProps,
+  ref?: ForwardedRef<HTMLTableHeaderCellElement>,
+) {
   return (
     <ThStyle
       $interactive={!!rest.onClick}

--- a/packages/table/Thead.tsx
+++ b/packages/table/Thead.tsx
@@ -1,11 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { TheadProps } from './types'
-
 import { TheadStyle } from './styles'
 
-function Thead(props: TheadProps, ref?: ForwardedRef<HTMLTableSectionElement>) {
-  const { sticky = false, ...rest } = props
-
+function Thead(
+  { sticky = false, ...rest }: TheadProps,
+  ref?: ForwardedRef<HTMLTableSectionElement>,
+) {
   return <TheadStyle ref={ref} $sticky={sticky} {...rest} />
 }
 

--- a/packages/table/Tr.tsx
+++ b/packages/table/Tr.tsx
@@ -1,11 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { TrProps } from './types'
-
 import { TrStyle } from './styles'
 
-function Tr(props: TrProps, ref?: ForwardedRef<HTMLTableRowElement>) {
-  const { highlight, ...rest } = props
-
+function Tr(
+  { highlight, ...rest }: TrProps,
+  ref?: ForwardedRef<HTMLTableRowElement>,
+) {
   return (
     <TrStyle
       $highlight={highlight}

--- a/packages/text/Text.tsx
+++ b/packages/text/Text.tsx
@@ -1,15 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef } from 'react'
 import { TextStyle } from './TextStyles'
 import { TextProps } from './types'
 
-function Text(props: TextProps, ref?: ForwardedRef<HTMLParagraphElement>) {
-  const {
-    size = 'md',
-    weight = 400,
-    color = 'default',
-    strong,
-    ...rest
-  } = props
+function Text(
+  { size = 'md', weight = 400, color = 'default', strong, ...rest }: TextProps,
+  ref?: ForwardedRef<HTMLParagraphElement>,
+) {
   return (
     <TextStyle
       size={size}

--- a/packages/text/TextStyles.tsx
+++ b/packages/text/TextStyles.tsx
@@ -36,12 +36,7 @@ type InjectedProps = {
   theme: Theme
 } & Omit<TextProps, 'color' | 'size' | 'strong' | 'weight'>
 
-const getTextColor = (props: InjectedProps) => {
-  const {
-    theme: { colors },
-    color,
-  } = props
-
+const getTextColor = ({ theme: { colors }, color }: InjectedProps) => {
   const colorsMap = {
     default: colors.text,
     secondary: colors.textSecondary,
@@ -54,9 +49,7 @@ const getTextColor = (props: InjectedProps) => {
   return colorsMap[color]
 }
 
-const getTextDecoration = (props: InjectedProps) => {
-  const { underline, strikeThrough } = props
-
+const getTextDecoration = ({ underline, strikeThrough }: InjectedProps) => {
   switch (true) {
     case underline:
       return 'underline'

--- a/packages/theme/cookie-theme-provider.tsx
+++ b/packages/theme/cookie-theme-provider.tsx
@@ -1,6 +1,7 @@
-import React, {
+import {
   createContext,
   FC,
+  memo,
   PropsWithChildren,
   useContext,
   useEffect,
@@ -41,7 +42,7 @@ export const CookieThemeProvider: FC<
     initialThemeName?: ThemeName
     overrideThemeName?: ThemeName
   }>
-> = React.memo(
+> = memo(
   ({
     children,
     initialThemeName,

--- a/packages/theme/document-head-contents/element-fonts.tsx
+++ b/packages/theme/document-head-contents/element-fonts.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const CSS_FONTS = `@import url(https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800);
 body {
 font-family: Manrope, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,

--- a/packages/theme/document-head-contents/element-theme-colors.tsx
+++ b/packages/theme/document-head-contents/element-theme-colors.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { themeDark, themeLight } from '../themes'
 import { generateCssColorVariables } from '../utils/generate-css-color-variables'
 import { globalStyleDataAttribute, ThemeName } from '../constants'

--- a/packages/theme/document-head-contents/element-theme-script.tsx
+++ b/packages/theme/document-head-contents/element-theme-script.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { VOID_FN } from '@lidofinance/utils'
 import { themeCookieKey, ThemeName } from '../constants'
 import { setThemeCookie } from '../utils/set-theme-cookie'

--- a/packages/theme/document-head-contents/index.tsx
+++ b/packages/theme/document-head-contents/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { Fonts } from './element-fonts'
 import { initGlobalColors, StyleThemeColors } from './element-theme-colors'
 import { initGlobalCookieTheme, ScriptThemeValue } from './element-theme-script'

--- a/packages/theme/theme-provider.tsx
+++ b/packages/theme/theme-provider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+import { FC, PropsWithChildren } from 'react'
 import styled, { ThemeProvider as StyledThemeProvider } from 'styled-components'
 import { reverseThemeMap, themeDark, themeDefault, themeLight } from './themes'
 import { initColors } from './document-head-contents'

--- a/packages/toast/Toast.stories.tsx
+++ b/packages/toast/Toast.stories.tsx
@@ -28,8 +28,7 @@ export default {
   },
 } as Meta
 
-export const Basic: Story = (props) => {
-  const { text, ...options } = props
+export const Basic: Story = ({ text, ...options }) => {
   const notifyDefault = () => ToastDefault(text, options)
 
   return (
@@ -48,8 +47,7 @@ export const Basic: Story = (props) => {
   )
 }
 
-export const Error: Story = (props) => {
-  const { text, ...options } = props
+export const Error: Story = ({ text, ...options }) => {
   const notifyError = () => ToastError(text, options)
 
   return (
@@ -62,8 +60,7 @@ export const Error: Story = (props) => {
   )
 }
 
-export const Success: Story = (props) => {
-  const { text, ...options } = props
+export const Success: Story = ({ text, ...options }) => {
   const notifySuccess = () => ToastSuccess(text, options)
 
   return (
@@ -76,8 +73,7 @@ export const Success: Story = (props) => {
   )
 }
 
-export const Info: Story = (props) => {
-  const { text, ...options } = props
+export const Info: Story = ({ text, ...options }) => {
   const notifyInfo = () => ToastInfo(text, options)
 
   return (
@@ -90,8 +86,7 @@ export const Info: Story = (props) => {
   )
 }
 
-export const Pending: Story = (props) => {
-  const { text, ...options } = props
+export const Pending: Story = ({ text, ...options }) => {
   const notifyPending = () => ToastPending(text, options)
   const dismissAll = () => toast.dismiss()
 

--- a/packages/toast/ToastPending.tsx
+++ b/packages/toast/ToastPending.tsx
@@ -1,4 +1,4 @@
-import React, { ReactText } from 'react'
+import { ReactText } from 'react'
 import { toast, ToastOptions } from 'react-toastify'
 import {
   ToastPendingLoaderStyle,

--- a/packages/tooltip/Tooltip.tsx
+++ b/packages/tooltip/Tooltip.tsx
@@ -1,10 +1,11 @@
-import React, {
+import {
   ForwardedRef,
   forwardRef,
   Children,
   useRef,
   cloneElement,
   useState,
+  MouseEvent,
 } from 'react'
 import { TooltipPopoverStyle } from './TooltipStyles'
 import { useMergeRefs } from '@lidofinance/hooks'
@@ -13,9 +14,10 @@ import { TooltipProps } from './types'
 
 const BODY_PERSISTENT_TIMEOUT = 150
 
-function Tooltip(props: TooltipProps, ref?: ForwardedRef<HTMLDivElement>) {
-  const { title, children, ...rest } = props
-
+function Tooltip(
+  { title, children, ...rest }: TooltipProps,
+  ref?: ForwardedRef<HTMLDivElement>,
+) {
   const [state, setState] = useState(false)
   const keepTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -44,11 +46,11 @@ function Tooltip(props: TooltipProps, ref?: ForwardedRef<HTMLDivElement>) {
     <>
       {cloneElement(child, {
         ref: mergedRef,
-        onMouseEnter(event: React.MouseEvent<HTMLElement, MouseEvent>) {
+        onMouseEnter(event: MouseEvent<HTMLElement>) {
           handleMouseEnter()
           child.props.onMouseEnter?.(event)
         },
-        onMouseLeave(event: React.MouseEvent<HTMLElement, MouseEvent>) {
+        onMouseLeave(event: MouseEvent<HTMLElement>) {
           handleMouseLeave()
           child.props.onMouseLeave?.(event)
         },

--- a/packages/tooltip/types.ts
+++ b/packages/tooltip/types.ts
@@ -1,11 +1,11 @@
 import { PopoverProps } from '@lidofinance/popover'
-import React from 'react'
+import { ReactElement, ReactNode, RefAttributes } from 'react'
 export type { Theme } from '@lidofinance/theme'
 
 export type TooltipProps = Omit<
   PopoverProps,
   'anchorRef' | 'title' | 'open' | 'backdrop' | 'children'
 > & {
-  title: React.ReactNode
-  children: React.ReactElement & React.RefAttributes<HTMLElement>
+  title: ReactNode
+  children: ReactElement & RefAttributes<HTMLElement>
 }

--- a/packages/transition/withTransition.tsx
+++ b/packages/transition/withTransition.tsx
@@ -1,4 +1,11 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import {
+  ComponentType,
+  ForwardedRef,
+  forwardRef,
+  ForwardRefExoticComponent,
+  PropsWithoutRef,
+  RefAttributes,
+} from 'react'
 import { useMergeRefs } from '@lidofinance/hooks'
 import { Transition } from 'react-transition-group'
 import { DEFAULT_DURATION } from './constants'
@@ -11,12 +18,12 @@ export default function withTransition<
   P extends TransitionInnerProps,
   E extends HTMLElement,
 >(
-  Component: React.ComponentType<P>,
-): React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<WrappedProps<P>> & React.RefAttributes<E>
+  Component: ComponentType<P>,
+): ForwardRefExoticComponent<
+  PropsWithoutRef<WrappedProps<P>> & RefAttributes<E>
 > {
-  function Wrapped(props: WrappedProps<P>, externalRef: ForwardedRef<E>) {
-    const {
+  function Wrapped(
+    {
       in: state = false,
       timeout = DEFAULT_DURATION,
       mountOnEnter = true,
@@ -32,8 +39,9 @@ export default function withTransition<
       onExiting,
       onExited,
       ...rest
-    } = props
-
+    }: WrappedProps<P>,
+    externalRef: ForwardedRef<E>,
+  ) {
     const transitionProps = {
       in: state,
       timeout,

--- a/scripts/build.cjs
+++ b/scripts/build.cjs
@@ -5,7 +5,7 @@ const main = async () => {
   await $`rm -rf ./dist`
   await $`swc ./packages --no-swcrc --config-file .swcrc.commonjs -d ./dist/cjs`
   await $`swc ./packages --no-swcrc --config-file .swcrc.esm -d ./dist/esm`
-  await $`tsc --emitDeclarationOnly --outDir ./dist/types`
+  await $`tsc --project tsconfig.production.json`
 }
 
 void main()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,5 +64,9 @@
     }
   },
   "files": ["packages/index.ts"],
+  "include": [
+    "packages/**/*.stories.ts",
+    "packages/**/*.stories.tsx",
+  ],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,8 @@
   },
   "files": ["packages/index.ts"],
   "include": [
+    "packages/**/*.test.ts",
+    "packages/**/*.test.tsx",
     "packages/**/*.stories.ts",
     "packages/**/*.stories.tsx",
   ],

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types"
+  },
+  "exclude": [
+    "packages/**/*.stories.ts",
+    "packages/**/*.stories.tsx",
+  ]
+}

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -5,6 +5,8 @@
     "outDir": "./dist/types"
   },
   "exclude": [
+    "packages/**/*.test.ts",
+    "packages/**/*.test.tsx",
     "packages/**/*.stories.ts",
     "packages/**/*.stories.tsx",
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,19 +1960,19 @@
     "@types/node" "*"
     jest-mock "^29.0.1"
 
-"@jest/expect-utils@^28.1.3":
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz#58561ce5db7cd253a7edddbc051fb39dda50f525"
-  integrity sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==
-  dependencies:
-    jest-get-type "^28.0.2"
-
 "@jest/expect-utils@^29.0.1":
   version "29.0.1"
   resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.0.1.tgz#c1a84ee66caaef537f351dd82f7c63d559cf78d5"
   integrity sha512-Tw5kUUOKmXGQDmQ9TSgTraFFS7HMC1HG/B7y0AN2G2UzjdAXz9BzK2rmNpCSDl7g7y0Gf/VLBm//blonvhtOTQ==
   dependencies:
     jest-get-type "^29.0.0"
+
+"@jest/expect-utils@^29.6.2":
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.6.2.tgz#1b97f290d0185d264dd9fdec7567a14a38a90534"
+  integrity sha512-6zIhM8go3RV2IG4aIZaZbxwpOzz3ZiM23oxAlkquOIole+G6TrbeXnykxWYlqF7kz2HlBjdKtca20x9atkEQYg==
+  dependencies:
+    jest-get-type "^29.4.3"
 
 "@jest/expect@^29.0.1":
   version "29.0.1"
@@ -2034,13 +2034,6 @@
     strip-ansi "^6.0.0"
     terminal-link "^2.0.0"
     v8-to-istanbul "^9.0.1"
-
-"@jest/schemas@^28.1.3":
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz#ad8b86a66f11f33619e3d7e1dcddd7f2d40ff905"
-  integrity sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==
-  dependencies:
-    "@sinclair/typebox" "^0.24.1"
 
 "@jest/schemas@^29.0.0":
   version "29.0.0"
@@ -2136,18 +2129,6 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^28.1.3":
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz#b05de80996ff12512bc5ceb1d208285a7d11748b"
-  integrity sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==
-  dependencies:
-    "@jest/schemas" "^28.1.3"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
 "@jest/types@^29.0.1":
@@ -4315,13 +4296,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^28.1.8":
-  version "28.1.8"
-  resolved "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz#6936409f3c9724ea431efd412ea0238a0f03b09b"
-  integrity sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==
+"@types/jest@^29.5.3":
+  version "29.5.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.3.tgz#7a35dc0044ffb8b56325c6802a4781a626b05777"
+  integrity sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==
   dependencies:
-    expect "^28.0.0"
-    pretty-format "^28.0.0"
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/jsdom@^20.0.0":
   version "20.0.0"
@@ -5609,6 +5590,13 @@ browserslist@^4.21.10, browserslist@^4.21.9:
     node-releases "^2.0.13"
     update-browserslist-db "^1.0.11"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -6626,15 +6614,15 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diff-sequences@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
-  integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
-
 diff-sequences@^29.0.0:
   version "29.0.0"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz#bae49972ef3933556bcb0800b72e8579d19d9e4f"
   integrity sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==
+
+diff-sequences@^29.4.3:
+  version "29.4.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
+  integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -7417,16 +7405,17 @@ exit@^0.1.2:
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^28.0.0:
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz#90a7c1a124f1824133dd4533cce2d2bdcb6603ec"
-  integrity sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==
+expect@^29.0.0:
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.6.2.tgz#7b08e83eba18ddc4a2cf62b5f2d1918f5cd84521"
+  integrity sha512-iAErsLxJ8C+S02QbLAwgSGSezLQK+XXRDt8IuFXFpwCNw2ECmzZSmjKcCaFVp5VRMk+WAvz6h6jokzEzBFZEuA==
   dependencies:
-    "@jest/expect-utils" "^28.1.3"
-    jest-get-type "^28.0.2"
-    jest-matcher-utils "^28.1.3"
-    jest-message-util "^28.1.3"
-    jest-util "^28.1.3"
+    "@jest/expect-utils" "^29.6.2"
+    "@types/node" "*"
+    jest-get-type "^29.4.3"
+    jest-matcher-utils "^29.6.2"
+    jest-message-util "^29.6.2"
+    jest-util "^29.6.2"
 
 expect@^29.0.1:
   version "29.0.1"
@@ -7528,7 +7517,7 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -9069,16 +9058,6 @@ jest-config@^29.0.1:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^28.1.3:
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz#948a192d86f4e7a64c5264ad4da4877133d8792f"
-  integrity sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^28.1.1"
-    jest-get-type "^28.0.2"
-    pretty-format "^28.1.3"
-
 jest-diff@^29.0.1:
   version "29.0.1"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-29.0.1.tgz#d14e900a38ee4798d42feaaf0c61cb5b98e4c028"
@@ -9088,6 +9067,16 @@ jest-diff@^29.0.1:
     diff-sequences "^29.0.0"
     jest-get-type "^29.0.0"
     pretty-format "^29.0.1"
+
+jest-diff@^29.6.2:
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.6.2.tgz#c36001e5543e82a0805051d3ceac32e6825c1c46"
+  integrity sha512-t+ST7CB9GX5F2xKwhwCf0TAR17uNDiaPTZnVymP9lw0lssa9vG+AFyDZoeIHStU3WowFFwT+ky+er0WVl2yGhA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.4.3"
+    jest-get-type "^29.4.3"
+    pretty-format "^29.6.2"
 
 jest-docblock@^29.0.0:
   version "29.0.0"
@@ -9133,15 +9122,15 @@ jest-environment-node@^29.0.1:
     jest-mock "^29.0.1"
     jest-util "^29.0.1"
 
-jest-get-type@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
-  integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
-
 jest-get-type@^29.0.0:
   version "29.0.0"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz#843f6c50a1b778f7325df1129a0fd7aa713aef80"
   integrity sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==
+
+jest-get-type@^29.4.3:
+  version "29.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.4.3.tgz#1ab7a5207c995161100b5187159ca82dd48b3dd5"
+  integrity sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==
 
 jest-haste-map@^29.0.1:
   version "29.0.1"
@@ -9189,16 +9178,6 @@ jest-leak-detector@^29.0.1:
     jest-get-type "^29.0.0"
     pretty-format "^29.0.1"
 
-jest-matcher-utils@^28.1.3:
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz#5a77f1c129dd5ba3b4d7fc20728806c78893146e"
-  integrity sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==
-  dependencies:
-    chalk "^4.0.0"
-    jest-diff "^28.1.3"
-    jest-get-type "^28.0.2"
-    pretty-format "^28.1.3"
-
 jest-matcher-utils@^29.0.1:
   version "29.0.1"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.0.1.tgz#eaa92dd5405c2df9d31d45ec4486361d219de3e9"
@@ -9209,20 +9188,15 @@ jest-matcher-utils@^29.0.1:
     jest-get-type "^29.0.0"
     pretty-format "^29.0.1"
 
-jest-message-util@^28.1.3:
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz#232def7f2e333f1eecc90649b5b94b0055e7c43d"
-  integrity sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==
+jest-matcher-utils@^29.6.2:
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.6.2.tgz#39de0be2baca7a64eacb27291f0bd834fea3a535"
+  integrity sha512-4LiAk3hSSobtomeIAzFTe+N8kL6z0JtF3n6I4fg29iIW7tt99R7ZcIFW34QkX+DuVrf+CUe6wuVOpm7ZKFJzZQ==
   dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^28.1.3"
-    "@types/stack-utils" "^2.0.0"
     chalk "^4.0.0"
-    graceful-fs "^4.2.9"
-    micromatch "^4.0.4"
-    pretty-format "^28.1.3"
-    slash "^3.0.0"
-    stack-utils "^2.0.3"
+    jest-diff "^29.6.2"
+    jest-get-type "^29.4.3"
+    pretty-format "^29.6.2"
 
 jest-message-util@^29.0.1:
   version "29.0.1"
@@ -9236,6 +9210,21 @@ jest-message-util@^29.0.1:
     graceful-fs "^4.2.9"
     micromatch "^4.0.4"
     pretty-format "^29.0.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-message-util@^29.6.2:
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.6.2.tgz#af7adc2209c552f3f5ae31e77cf0a261f23dc2bb"
+  integrity sha512-vnIGYEjoPSuRqV8W9t+Wow95SDp6KPX2Uf7EoeG9G99J2OVh7OSwpS4B6J0NfpEIpfkBNHlBZpA2rblEuEFhZQ==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.1"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.6.2"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
@@ -9377,12 +9366,12 @@ jest-styled-components@^7.1.1:
   dependencies:
     "@adobe/css-tools" "^4.0.1"
 
-jest-util@^28.1.3:
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz#f4f932aa0074f0679943220ff9cbba7e497028b0"
-  integrity sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==
+jest-util@^29.0.0, jest-util@^29.6.2:
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.6.2.tgz#8a052df8fff2eebe446769fd88814521a517664d"
+  integrity sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==
   dependencies:
-    "@jest/types" "^28.1.3"
+    "@jest/types" "^29.6.1"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -9395,18 +9384,6 @@ jest-util@^29.0.1:
   integrity sha512-GIWkgNfkeA9d84rORDHPGGTFBrRD13A38QVSKE0bVrGSnoR1KDn8Kqz+0yI5kezMgbT/7zrWaruWP1Kbghlb2A==
   dependencies:
     "@jest/types" "^29.0.1"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
-jest-util@^29.6.2:
-  version "29.6.2"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.6.2.tgz#8a052df8fff2eebe446769fd88814521a517664d"
-  integrity sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==
-  dependencies:
-    "@jest/types" "^29.6.1"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -9605,7 +9582,7 @@ json5@^2.1.2, json5@^2.2.1:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
-json5@^2.2.2:
+json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -9957,6 +9934,11 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -10053,7 +10035,7 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1, make-error@^1.1.1:
+make-error@1.x, make-error@^1, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -11564,13 +11546,12 @@ pretty-format@^27.0.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-pretty-format@^28.0.0, pretty-format@^28.1.3:
-  version "28.1.3"
-  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz#c9fba8cedf99ce50963a11b27d982a9ae90970d5"
-  integrity sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==
+pretty-format@^29.0.0, pretty-format@^29.6.2:
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.6.2.tgz#3d5829261a8a4d89d8b9769064b29c50ed486a47"
+  integrity sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==
   dependencies:
-    "@jest/schemas" "^28.1.3"
-    ansi-regex "^5.0.1"
+    "@jest/schemas" "^29.6.0"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
@@ -13612,6 +13593,20 @@ ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   resolved "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
+ts-jest@^29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.1.tgz#f58fe62c63caf7bfcc5cc6472082f79180f0815b"
+  integrity sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^29.0.0"
+    json5 "^2.2.3"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "^7.5.3"
+    yargs-parser "^21.0.1"
+
 ts-node@^9:
   version "9.1.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
@@ -14386,7 +14381,7 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.9:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==


### PR DESCRIPTION
### Description

- Moved props destruction to params level
- Removed plain React imports and replaced `React.someExport` usage with just `someExport`
- Added storybook to tsconfig, so it is also checked and there is no React import requirement
- Excluded storybook files from production build (this doesn't fix old issue with types, so it's not a major release)
- Simplified jest config