### PR TITLE
Fixed react runtime import by changing runtime react swc config

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -10,6 +10,7 @@
     },
     "transform": {
       "react": {
+        "runtime": "automatic",
         "pragma": "React.createElement",
         "pragmaFrag": "React.Fragment",
         "throwIfNamespace": true,
@@ -126,6 +127,9 @@
       ],
       "@lidofinance/content-theme": [
         "packages/content-theme"
+      ],
+      "@lidofinance/cookies-tooltip": [
+        "packages/cookies-tooltip"
       ]
     },
     "target": "es2019",

--- a/.swcrc.commonjs
+++ b/.swcrc.commonjs
@@ -10,6 +10,7 @@
     },
     "transform": {
       "react": {
+        "runtime": "automatic",
         "pragma": "React.createElement",
         "pragmaFrag": "React.Fragment",
         "throwIfNamespace": true,
@@ -126,6 +127,9 @@
       ],
       "@lidofinance/content-theme": [
         "packages/content-theme"
+      ],
+      "@lidofinance/cookies-tooltip": [
+        "packages/cookies-tooltip"
       ]
     },
     "target": "es2019",

--- a/.swcrc.esm
+++ b/.swcrc.esm
@@ -10,6 +10,7 @@
     },
     "transform": {
       "react": {
+        "runtime": "automatic",
         "pragma": "React.createElement",
         "pragmaFrag": "React.Fragment",
         "throwIfNamespace": true,
@@ -126,6 +127,9 @@
       ],
       "@lidofinance/content-theme": [
         "packages/content-theme"
+      ],
+      "@lidofinance/cookies-tooltip": [
+        "packages/cookies-tooltip"
       ]
     },
     "target": "es2019",

--- a/scripts/swcrc-template.cjs
+++ b/scripts/swcrc-template.cjs
@@ -10,6 +10,7 @@ module.exports = {
     },
     transform: {
       react: {
+        runtime: 'automatic',
         pragma: 'React.createElement',
         pragmaFrag: 'React.Fragment',
         throwIfNamespace: true,


### PR DESCRIPTION
### Description

Bug showed after https://github.com/lidofinance/ui/pull/449. If we remove manual React imports, then this component won't work anywhere else, because of missing React import.

This issue actually may have fired at any moment because React imports wasn't enforced in any mean, so it was more luck than actual engineering practice, that it didn't break before.

### Demo

<img width="658" alt="image" src="https://github.com/lidofinance/ui/assets/103929444/9563aa11-69d1-43b3-a333-4cc56f18aa7c">
