### PR TITLE
Fix broken esm imports from react-jazzicon

### DIFF
--- a/packages/identicon/Identicon.tsx
+++ b/packages/identicon/Identicon.tsx
@@ -1,9 +1,17 @@
 import { ForwardedRef, forwardRef } from 'react'
 import { IdenticonProps } from './types.js'
 import { IdenticonStyle } from './IdenticonStyles.js'
-import Jazzicon from 'react-jazzicon'
-// There is an error with importing jsNumberForAddress as named export in ESM build
-import jsNumberForAddress from 'react-jazzicon/dist/jsNumberForAddress.js'
+import _Jazzicon from 'react-jazzicon'
+
+// There is an error with importing jsNumberForAddress from 'react-jazzicon' as named export in ESM build
+// Since the implementation is tiny, moving it here
+const jsNumberForAddress = (address: string): number => {
+  const addr = address.slice(2, 10)
+  return parseInt(addr, 16) // seed
+}
+
+//@ts-expect-error Property default doesn't exist on type
+const Jazzicon = _Jazzicon.default || _Jazzicon
 
 export const Identicon = forwardRef(
   (


### PR DESCRIPTION
Follow up for #460 
It turned out, that imports from `react-jazzicon` are breaking in runtime.
This PR fixes it. 