### PR TITLE
Remove `type: module` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",


### PR DESCRIPTION
Follow-up for https://github.com/lidofinance/ui/pull/460
`type: module` field makes stake widget on next.js to treat this module as ESM.
It fixes incompatibility with reef-knot on the widget, which was the reason of all this changes.
But it creates another unexpected problem on the widget during SSR of the pages with `styled-components` import, which looks like this:
```
error - TypeError: d is not a function
    at <...>/ethereum-staking-widget/node_modules/styled-components/dist/styled-components.cjs.js:1:18879
    at <...>
```
`d` here is a default export, which most likely is `undefined`.
Looks like node imports styled-components as cjs (because it is SSR) and something goes wrong.
The widget's bundle for browsers contains `__webpack_require__` calls for `styled-components.browser.esm.js` and seems to work okay.

Because it may break builds of our widgets, removing `type: module` from package.json, so the package will still be treated as CJS.
The ESM build becomes not used, but it still looks more correct anyway.