### PR TITLE
Passed missed disabled & id props

### DIFF
--- a/packages/input/Input.tsx
+++ b/packages/input/Input.tsx
@@ -76,6 +76,8 @@ export const Input = forwardRef(
               aria-invalid={hasError}
               type='text'
               ref={ref}
+              id={id}
+              disabled={disabled}
               {...rest}
             />
             {hasLabel && (


### PR DESCRIPTION
### Description

Passed `disabled` and `id` states to inner input, they were missed during previous refactoring of props passing logic :( 

### Demo

https://github.com/lidofinance/ui/assets/103929444/6edd4e12-69e4-4e69-a7aa-fe29ff05892c


