### PR TITLE
fix: import default interop in styled-system

### DIFF
--- a/packages/styled-system/withStyledSystem.tsx
+++ b/packages/styled-system/withStyledSystem.tsx
@@ -10,7 +10,12 @@ import styled, {
   StyledComponentInnerAttrs,
   DefaultTheme,
 } from '../utils/styled-components-wrapper.js'
-import shouldForwardProp from '@styled-system/should-forward-prop'
+
+// The `@styled-system/should-forward-prop` has issues with ESM modules:
+import _shouldForwardProp from '@styled-system/should-forward-prop'
+// @ts-expect-error Property 'default' does not exist on type 'genericShouldForwardProp'
+const shouldForwardProp = _shouldForwardProp.default || _shouldForwardProp
+
 import {
   compose,
   space,


### PR DESCRIPTION
Added var wrapper 
```
const shouldForwardProp = _shouldForwardProp.default || _shouldForwardProp
```

for importing `'@styled-system/should-forward-prop'`
