### PR TITLE
fix: hydration when pass a theme as query param

### DIFF
--- a/packages/theme/cookie-theme-provider.tsx
+++ b/packages/theme/cookie-theme-provider.tsx
@@ -59,7 +59,7 @@ export const CookieThemeProvider: FC<
     // we always start with default theme, or, if server wants to provide
     // specific default theme, with server-provided theme to avoid hydration errors
     const [internalThemeName, setThemeName] = useState<ThemeName>(
-      getThemeNameFromUrl() || initialThemeName || DEFAULT_THEME_NAME,
+      initialThemeName || DEFAULT_THEME_NAME,
     )
     // since we're using this component to provide cookie-theme,
     // we eventually want to respect theme provided in cookie, not general theme,


### PR DESCRIPTION
Fix a hydration error in components using `withStyledSystem` wrapper when get a theme from query param. Actual on SSR mode only.