### PR TITLE
chore: update default viewports in storybook

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -4,8 +4,44 @@ import './styles/storybook.css'
 import '../styles/global.css'
 import { Decorator } from '@storybook/react'
 
+const defaultViewports = {
+  px1500: {
+    name: '1500px',
+    styles: {
+      width: '1500px',
+      height: '500px',
+    },
+  },
+  px900: {
+    name: '900px',
+    styles: {
+      width: '900px',
+      height: '800px',
+    },
+  },
+  px600: {
+    name: '600px',
+    styles: {
+      width: '600px',
+      height: '800px',
+    },
+  },
+  px500: {
+    name: '500px',
+    styles: {
+      width: '500px',
+      height: '800px',
+    },
+  },
+}
+
 export const parameters = {
   controls: { hideNoControlsWarning: true },
+  viewport: {
+    viewports: {
+      ...defaultViewports,
+    },
+  },
 }
 export const args = {
   themeOverride: 'light',


### PR DESCRIPTION
Now we'd be able to use predefined viewports
<img width="289" alt="Screenshot 2025-04-02 at 19 05 15" src="https://github.com/user-attachments/assets/7913a2e4-3328-42a2-967b-3818cd03ec09" />
