### PR TITLE
Cookies Tooltip – add privacyLinkEnabled prop

### DIFF
--- a/packages/cookies-tooltip/cookies-tooltip.stories.tsx
+++ b/packages/cookies-tooltip/cookies-tooltip.stories.tsx
@@ -26,3 +26,62 @@ export const Basic: StoryFn = () => (
     <CookiesTooltip />
   </>
 )
+
+export const WithPrivacyLinkEnabled: StoryFn = () => (
+  <>
+    <Text>
+      This story shows the CookiesTooltip with the privacy link enabled (default
+      behavior). The privacy link appears in the text and links to the privacy
+      notice.
+    </Text>
+    <CookiesTooltip privacyLinkEnabled={true} />
+  </>
+)
+
+export const WithPrivacyLinkDisabled: StoryFn = () => (
+  <>
+    <Text>
+      This story shows the CookiesTooltip with the privacy link disabled. Notice
+      that no privacy link appears in the text.
+    </Text>
+    <CookiesTooltip privacyLinkEnabled={false} />
+  </>
+)
+
+export const WithCustomPrivacyTextAndLink: StoryFn = () => (
+  <>
+    <Text>
+      This story shows the CookiesTooltip with custom privacy text and a custom
+      privacy link. The privacy link is enabled and points to a custom URL.
+    </Text>
+    <CookiesTooltip
+      privacyLinkEnabled={true}
+      privacyLink='https://example.com/custom-privacy'
+      privacyText={
+        <>
+          We use cookies to enhance your experience on our website. By
+          continuing to browse, you agree to our use of cookies.
+        </>
+      }
+    />
+  </>
+)
+
+export const WithCustomPrivacyTextNoLink: StoryFn = () => (
+  <>
+    <Text>
+      This story shows the CookiesTooltip with custom privacy text but no
+      privacy link. Even though custom text is provided, the privacy link is
+      disabled.
+    </Text>
+    <CookiesTooltip
+      privacyLinkEnabled={false}
+      privacyText={
+        <>
+          We use cookies to improve our services. You can accept or decline
+          cookies using the buttons below.
+        </>
+      }
+    />
+  </>
+)

--- a/packages/cookies-tooltip/cookies-tooltip.tsx
+++ b/packages/cookies-tooltip/cookies-tooltip.tsx
@@ -25,11 +25,13 @@ export type CookiesTooltipProps = Omit<
 > & {
   privacyText?: ReactNode
   privacyLink?: string
+  privacyLinkEnabled?: boolean
 }
 
 export const CookiesTooltip: FC<CookiesTooltipProps> = ({
   privacyText,
   privacyLink,
+  privacyLinkEnabled = true,
   ...rest
 }) => {
   const [isVisible, setVisibility] = useState(false)
@@ -64,13 +66,17 @@ export const CookiesTooltip: FC<CookiesTooltipProps> = ({
           {privacyText ?? (
             <>
               Cookies are used to collect anonymous site visitation data
-              to&nbsp;improve website performance. For&nbsp;more info,
-              read&nbsp;
+              to&nbsp;improve website performance.
+              {privacyLinkEnabled && <>&nbsp;For&nbsp;more info, read&nbsp;</>}
             </>
           )}
-          <ExternalLink href={privacyLink ?? 'https://lido.fi/privacy-notice'}>
-            Privacy Notice
-          </ExternalLink>
+          {privacyLinkEnabled && (
+            <ExternalLink
+              href={privacyLink ?? 'https://lido.fi/privacy-notice'}
+            >
+              Privacy Notice
+            </ExternalLink>
+          )}
         </Text>
         <ButtonsWrap>
           <AllowButton


### PR DESCRIPTION
This PR:
1. Adds `privacyLinkEnabled` prop to control Privacy Link visibility – I need to hide it on the ETH Stake Widget in the IPFS mode. By default the link is enabled, but it can be explicitly set to `false` if needed.
2. Adds storybook stories for CookiesTooltip, including the new behavior
