### PR TITLE
feat: add window size support to Modal component and window props

### DIFF
--- a/packages/modal/Modal.stories.tsx
+++ b/packages/modal/Modal.stories.tsx
@@ -6,7 +6,13 @@ import { Loader } from '../loaders/index.js'
 import { Text } from '../text/index.js'
 import { Link } from '../link/index.js'
 import { Error, Success, Eth, Terra } from '../icons/index.js'
-import { ModalProps, Modal, ModalExtra, ModalButton } from './index.js'
+import {
+  ModalProps,
+  Modal,
+  ModalExtra,
+  ModalButton,
+  ModalWindowSize,
+} from './index.js'
 
 const getOptions = (enumObject: Record<string, string | number>) =>
   Object.values(enumObject).filter((value) => typeof value === 'string')
@@ -19,11 +25,16 @@ export default {
     subtitle: '',
     children: 'Modal content',
     center: false,
+    windowSize: 'sm',
   },
   argTypes: {
     onClose: {
       action: 'close',
       table: { disable: true },
+    },
+    windowSize: {
+      options: getOptions(ModalWindowSize),
+      control: 'inline-radio',
     },
   },
 } as Meta

--- a/packages/modal/Modal.tsx
+++ b/packages/modal/Modal.tsx
@@ -26,6 +26,8 @@ export const Modal = forwardRef(
       open,
       onClose,
       onBack,
+      windowSize = 'sm',
+      windowProps,
       ...rest
     }: ModalProps,
     ref?: ForwardedRef<HTMLDivElement>,
@@ -63,7 +65,7 @@ export const Modal = forwardRef(
         onBack={onBack}
         {...rest}
       >
-        <ModalStyle $center={center}>
+        <ModalStyle $center={center} $size={windowSize} {...windowProps}>
           <ModalBaseStyle>
             {modalHeader}
             {withSubtitle && (

--- a/packages/modal/ModalStyles.tsx
+++ b/packages/modal/ModalStyles.tsx
@@ -1,13 +1,29 @@
 import styled, { css } from '../utils/styled-components-wrapper.js'
 import { Close, ArrowBack } from '../icons/index.js'
 import { ButtonIcon } from '../button/index.js'
+import { ModalWindowSizes } from './types.js'
 
-export const ModalStyle = styled.div<{ $center: boolean }>`
+export const ModalWindowSizesMap = {
+  sm: css`
+    width: 432px;
+  `,
+  md: css`
+    width: 520px;
+  `,
+  lg: css`
+    width: 960px;
+  `,
+}
+
+export const ModalStyle = styled.div<{
+  $center: boolean
+  $size: ModalWindowSizes
+}>`
   ${({
     theme: { fontSizesMap, borderRadiusesMap, colors, boxShadows },
     $center,
+    $size,
   }) => css`
-    width: 432px;
     max-width: 100%;
     font-weight: 400;
     font-size: ${fontSizesMap.xs}px;
@@ -15,6 +31,8 @@ export const ModalStyle = styled.div<{ $center: boolean }>`
     text-align: ${$center ? 'center' : 'left'};
     border-radius: ${borderRadiusesMap.xl}px;
     box-shadow: ${boxShadows.xxl} ${colors.shadowDark};
+
+    ${ModalWindowSizesMap[$size]}
   `}
 `
 

--- a/packages/modal/types.tsx
+++ b/packages/modal/types.tsx
@@ -24,7 +24,17 @@ export type ModalProps = {
   extra?: ReactNode
   center?: boolean
   open?: boolean
+  windowSize?: ModalWindowSizes
+  windowProps?: ModalWindowProps
 } & Omit<ModalOverlayProps, 'title' | 'in'>
+
+export enum ModalWindowSize {
+  sm,
+  md,
+  lg,
+}
+export type ModalWindowSizes = keyof typeof ModalWindowSize
+export type ModalWindowProps = LidoComponentProps<'div'>
 
 export type ModalExtraProps = LidoComponentProps<'div'>
 


### PR DESCRIPTION

### New Feature: Modal Window Size Customization
* [`packages/modal/types.tsx`](diffhunk://#diff-efed8bc982b8db9f68e5ac548d08be5c8a3f203084504e3ea7b1e1072e2a8db7R27-R38): Added a `windowSize` prop to `ModalProps`, defined an enum `ModalWindowSize` with size options (`sm`, `md`, `lg`), and created a type alias `ModalWindowSizes` for the keys of the enum. Also introduced a `windowProps` prop for additional customization.
* [`packages/modal/Modal.tsx`](diffhunk://#diff-fd92dcaa18aca0a103d4e251fb91090229b0a22955ccc39e0c0e6ef6cfbc400bR29-R30): Updated the `Modal` component to accept the `windowSize` prop (defaulting to `'sm'`) and pass it, along with `windowProps`, to the styled component. [[1]](diffhunk://#diff-fd92dcaa18aca0a103d4e251fb91090229b0a22955ccc39e0c0e6ef6cfbc400bR29-R30) [[2]](diffhunk://#diff-fd92dcaa18aca0a103d4e251fb91090229b0a22955ccc39e0c0e6ef6cfbc400bL66-R68)

### Styling Enhancements
* [`packages/modal/ModalStyles.tsx`](diffhunk://#diff-fcd8b584d4ae9a01bad76f16298f55f9624c42a9a4346beb37681ac907f1f759R4-R35): Created a `ModalWindowSizesMap` object to define CSS styles for each size (`sm`, `md`, `lg`) and updated the `ModalStyle` styled component to apply the appropriate size styles dynamically.

### Storybook Updates
* [`packages/modal/Modal.stories.tsx`](diffhunk://#diff-b05a5244d3598a23aae5e26acdb23082accd1da66343446d00aa2a3e32e1e6f1R28-R38): Added the `windowSize` prop to the default args and configured it as an inline-radio control in the storybook.
* [`packages/modal/Modal.stories.tsx`](diffhunk://#diff-b05a5244d3598a23aae5e26acdb23082accd1da66343446d00aa2a3e32e1e6f1L9-R15): Updated the imports to include `ModalWindowSize` for use in the storybook.