### PR TITLE
Hide ProportionProgressLineStyle for zero value

### DIFF
--- a/packages/chart-proportion/ChartProportion.tsx
+++ b/packages/chart-proportion/ChartProportion.tsx
@@ -39,7 +39,7 @@ export const ChartProportion = forwardRef(
         {data.map((item, index) => {
           const { color, value, progress, label } = item
           const isShowLabel = showLabels && label
-          const showProgressLine = progress > 0 && progress < 100;
+          const showProgressLine = value > 0 && progress > 0 && progress < 100
 
           return (
             <ProportionStyle

--- a/packages/chart-proportion/ChartProportion.tsx
+++ b/packages/chart-proportion/ChartProportion.tsx
@@ -39,6 +39,7 @@ export const ChartProportion = forwardRef(
         {data.map((item, index) => {
           const { color, value, progress, label } = item
           const isShowLabel = showLabels && label
+          const showProgressLine = progress > 0 && progress < 100;
 
           return (
             <ProportionStyle
@@ -58,7 +59,7 @@ export const ChartProportion = forwardRef(
                 $border={border}
                 $borderSize={borderSize}
               >
-                {progress !== 100 && <ProportionProgressLineStyle />}
+                {showProgressLine && <ProportionProgressLineStyle />}
               </ProportionProgressStyle>
             </ProportionStyle>
           )


### PR DESCRIPTION
Hide chart proportion progress line for cases when a segment has value === 0

<img width="503" height="149" alt="Снимок экрана — 2026-07-03 в 12 37 00" src="https://github.com/user-attachments/assets/15ff2a94-026b-4091-a61c-6c886e261b6b" />
