### PR TITLE
feat: harden workflows

### DIFF
--- a/.github/workflows/_dry-run.yml
+++ b/.github/workflows/_dry-run.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-dry-run
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -26,12 +26,12 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Cache node_modules and turbo
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules

--- a/.github/workflows/ci-preview-demolish.yml
+++ b/.github/workflows/ci-preview-demolish.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build and deploy
     steps:
       - name: Preview stand deploying
-        uses: lidofinance/dispatch-workflow@v1
+        uses: lidofinance/dispatch-workflow@f6160026f09afc4076f8350b5e23a1a12e2c36b6 # v1
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci-preview-deploy.yml
+++ b/.github/workflows/ci-preview-deploy.yml
@@ -22,19 +22,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false }}
     name: Build and deploy
+    permissions:
+      pull-requests: read # for lidofinance/gh-find-current-pr
     outputs:
       stand_url: ${{ steps.stand.outputs.url }}
     steps:
-      - uses: lidofinance/gh-find-current-pr@v1
+      - uses: lidofinance/gh-find-current-pr@15e7a49f2d3f153952a3aa5e6ad6cfe07f770bd5 # v1
         id: pr
 
       - name: Set ref
@@ -42,7 +42,7 @@ jobs:
         run: echo "short_ref=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Preview stand deploying
-        uses: lidofinance/dispatch-workflow@v1
+        uses: lidofinance/dispatch-workflow@f6160026f09afc4076f8350b5e23a1a12e2c36b6 # v1
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
@@ -54,8 +54,10 @@ jobs:
           INPUTS_INVENTORY: "${{ inputs.inventory || 'testnet' }}"
 
       - name: Define repo short name
-        run: echo "short_name=$(echo ${{ github.repository }} | cut -d "/" -f 2)" >> $GITHUB_OUTPUT
+        run: echo "short_name=${REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
         id: repo
+        env:
+          REPOSITORY: ${{ github.repository }}
 
       - name: Define branch hash
         run: echo "hash=$(echo "$HEAD_REF" | shasum -a 256 | cut -c -10)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -6,9 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -18,18 +16,23 @@ jobs:
   build:
     environment: production
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the repository
+      pages: read # for actions/configure-pages to read the Pages site config
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Cache node_modules and turbo
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules
@@ -52,20 +55,23 @@ jobs:
           cp -r packages/lido-app-ui/storybook-static/. release-target/lido-app-ui/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: release-target
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -10,6 +10,8 @@ concurrency:
   group: publish-alpha
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   # Gate the whole alpha publish before the dry-run: a prerelease branch must
   # have main merged in, or semantic-release (which only sees tags merged into
@@ -24,9 +26,10 @@ jobs:
       - name: Ensure develop is not behind main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          behind=$(gh api "repos/${{ github.repository }}/compare/develop...main" --jq '.ahead_by')
+          behind=$(gh api "repos/$REPOSITORY/compare/develop...main" --jq '.ahead_by')
           # Fail closed: a non-numeric result (API error / unexpected body) must
           # block the publish, not silently pass the guard.
           if ! [[ "$behind" =~ ^[0-9]+$ ]]; then
@@ -56,7 +59,7 @@ jobs:
       NODE_OPTIONS: --max_old_space_size=4096
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -64,12 +67,12 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Cache node_modules and turbo
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -10,6 +10,8 @@ concurrency:
   group: publish-production
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   dry-run:
     uses: ./.github/workflows/_dry-run.yml
@@ -28,7 +30,7 @@ jobs:
       NODE_OPTIONS: --max_old_space_size=4096
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -36,12 +38,12 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Cache node_modules and turbo
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,28 +11,35 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 env:
   NODE_OPTIONS: --max_old_space_size=4096
 
 jobs:
   security:
-    uses: lidofinance/linters/.github/workflows/security.yml@master
+    permissions:
+      contents: read # the reusable workflow checks out this repository
+      security-events: write # codeql-action/analyze uploads SARIF results
+    uses: lidofinance/linters/.github/workflows/security.yml@ff208ca0bf93063c25becac743e1c4eb96d0aad9 # master
 
   docker:
-    uses: lidofinance/linters/.github/workflows/docker.yml@master
+    permissions:
+      contents: read # the reusable workflow checks out this repository
+    uses: lidofinance/linters/.github/workflows/docker.yml@ff208ca0bf93063c25becac743e1c4eb96d0aad9 # master
 
   actions:
-    uses: lidofinance/linters/.github/workflows/actions.yml@master
+    permissions:
+      contents: read # the reusable workflow checks out this repository
+    uses: lidofinance/linters/.github/workflows/actions.yml@ff208ca0bf93063c25becac743e1c4eb96d0aad9 # master
 
   cache-deps:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the repository
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -40,12 +47,12 @@ jobs:
         run: corepack enable
 
       - name: Set up node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Restore cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
@@ -56,9 +63,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     needs: cache-deps
+    permissions:
+      contents: read # to check out the repository
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -66,18 +75,18 @@ jobs:
         run: corepack enable
 
       - name: Set up node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Restore cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Cache turbo
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -93,9 +102,11 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     needs: cache-deps
+    permissions:
+      contents: read # to check out the repository
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -103,18 +114,18 @@ jobs:
         run: corepack enable
 
       - name: Set up node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Restore cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Cache turbo
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -131,9 +142,11 @@ jobs:
   demo-build:
     runs-on: ubuntu-latest
     needs: cache-deps
+    permissions:
+      contents: read # to check out the repository
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -141,18 +154,18 @@ jobs:
         run: corepack enable
 
       - name: Set up node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Restore cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Cache turbo
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}


### PR DESCRIPTION
Harden workflows for better security

Pinning:
- The three lidofinance/linters reusable workflows were pinned to @master. Pin them to ff208ca (current master tip, same hash landing already uses).
- Pin configure-pages, upload-pages-artifact, deploy-pages, gh-find-current-pr and dispatch-workflow by commit SHA instead of a major tag.
- Add the resolved version as a comment on the hashes that had none.

Permissions:
- test.yml granted `security-events: write` at the top level, so all seven jobs got it — including lint/run-tests/demo-build, which run `yarn install` on PR code. Only the `security` job needs it: its linter runs codeql-action/analyze, which uploads SARIF. Everything else now gets `contents: read`.
- deploy-storybook.yml handed `pages: write` + `id-token: write` to the build job too. Split per job: build gets `contents: read` + `pages: read`, deploy gets the write permissions.
- Deny at the top level everywhere and scope the remaining jobs.

Also:
- Add `persist-credentials: false` to the deploy-storybook checkout, the only one missing it.
- Replace `${{ github.repository }}` interpolation inside run blocks with an env variable in ci-preview-deploy.yml and publish-alpha.yml.

The dry-run job keeps `contents: write`: @semantic-release/github runs verifyConditions even in dry-run mode and checks for push permission, so narrowing it risks EGHNOPERMISSION, and dry-run gates every publish.