### PR TITLE
fix: emit lido-app-ui types at the path package.json declares

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,0 @@
-node_modules
-dist
-storybook-static
-packages/*/dist
-packages/*/node_modules
-packages/*/.storybook/styles

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -66,5 +66,8 @@ module.exports = {
       },
     },
   },
-  ignorePatterns: ['!.storybook'],
+  // Kept here rather than in .eslintignore: that file is only picked up from
+  // the directory eslint runs in, and every package lints itself with
+  // `eslint .` from its own folder, so the root one never applied to them.
+  ignorePatterns: ['node_modules', 'dist', 'storybook-static', '!.storybook'],
 }

--- a/packages/lido-app-ui/tsconfig.json
+++ b/packages/lido-app-ui/tsconfig.json
@@ -12,6 +12,8 @@
   },
   "include": [
     "**/*.d.ts",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
     "src/**/*.ts",
     "src/**/*.tsx"
   ],

--- a/packages/lido-app-ui/tsconfig.production.json
+++ b/packages/lido-app-ui/tsconfig.production.json
@@ -1,15 +1,23 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "emitDeclarationOnly": true,
-    "outDir": "./dist/types"
+    "outDir": "./dist/types",
+    "rootDir": "src",
+    "paths": {
+      "react": ["../../node_modules/@types/react"],
+      "@lidofinance/lido-shared-ui": ["../lido-shared-ui/dist/types"],
+      "@lidofinance/lido-shared-ui/*": ["../lido-shared-ui/dist/types/*"]
+    }
   },
+  "include": ["global.d.ts", "src/**/*.ts", "src/**/*.tsx"],
   "exclude": [
-    "src/**/*.test.ts",
-    "src/**/*.test.tsx",
+    "node_modules",
+    "dist",
     "src/**/*.stories.ts",
     "src/**/*.stories.tsx",
-    "node_modules",
-    "dist"
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
The paths in tsconfig pointed at lido-shared-ui sources, so its files joined the program, the inferred root became packages/, and declarations landed in dist/types/lido-app-ui/src. The declared types entry, dist/types/index.d.ts, did not exist and consumers got no types at all. Point the paths at the built declarations and pin rootDir to src, the way
lido-landing-ui already does. Also include .storybook in the dev tsconfig, matching the other packages, so preview.tsx is type-checked with the project's settings instead of editor defaults. Move the eslint ignores from .eslintignore into ignorePatterns: that file is only read from the directory eslint runs in, and every package lints itself from its own folder, so generated output under dist was being linted.